### PR TITLE
Fix coordinate order in GeoJSON, add all tracks route with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,44 @@
 This repo contains two npm modules:
 - `@signalk/tracks` - RxJs based module that accumulates positions into a track, using a configured time resolution and retains a sliding window of points. Contains the code for both a Signal K server plugin that implements the track api and client side "TrackAccumulator" class that manages the track for a single vessel. TrackAccumulator can optionally bootstrap the track data from the server. The result is available as `Observable<LatLng[]>`.
 - `@signalk/tracks-plugin` Convenience module that exposes the plugin part of `@signalk/tracks`.
+
+
+# Tracks
+Plugin for tracks accumulation and the track API
+
+
+# Usage:
+
+__Retrieve tracks for individual vessel:__
+
+`/signalk/v1/api/tracks/<vesselId>`
+
+---
+
+__Retrieve tracks for all vessels:__
+
+`/signalk/v1/api/tracks`
+
+_If `maxRadius` is specified only vessels with last track position within this distance are returned._
+
+---
+
+__Retrieve tracks for all vessels within a given radius (in meters) from your vessel position:__
+
+`/signalk/v1/api/tracks?radius=50000`
+
+_Note: This value overrides the `maxRadius` value specified in plugin configuration._
+
+---
+
+__Retrieve tracks for all vessels within a bounded area:__
+
+`/signalk/v1/api/tracks?bbox=130,-35,139,-33`
+
+_Bounded area is defined as `lon1, lat1, lon2, lat2`_
+
+_`lon1, lat1` = lower left corner of bounded area_
+
+_`lon2, lat2` = upper right corner of bounded area_
+
+---

--- a/module/package.json
+++ b/module/package.json
@@ -11,6 +11,7 @@
     "watch": "tsc --watch",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx --quiet --fix",
     "prettier": "prettier --write .",
+    "test": "mocha --require ts-node/register src/**/*.test.ts",
     "prepublishOnly": "npm run lint && tsc"
   },
   "license": "Apache-2.0",
@@ -18,13 +19,18 @@
     "rxjs": "^6.6.3"
   },
   "devDependencies": {
+    "@types/chai": "^4.2.15",
     "@types/express": "^4.17.9",
+    "@types/mocha": "^8.2.1",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",
+    "chai": "^4.3.0",
     "eslint": "^7.16.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-prettier": "^3.3.0",
+    "mocha": "^8.3.0",
     "prettier": "2.2.1",
+    "ts-node": "^9.1.1",
     "typescript": "^4.1.3"
   }
 }

--- a/module/src/index.ts
+++ b/module/src/index.ts
@@ -23,9 +23,11 @@ export interface ContextPosition {
   value: Position
 }
 
-interface VesselTrack {
-  type: string
-  coordinates: Array<Array<LatLngTuple>>
+interface AllTracksResult {
+  [context: string]: {
+    type: 'MultiLineString'
+    coordinates: LatLngTuple[][]
+  }
 }
 
 interface App {
@@ -115,14 +117,14 @@ export default function ThePlugin(app: App): Plugin {
         app.debug('** params **', params)
         tracks
           ?.getAll(params, getVesselPosition())
-          .then((d: TrackCollection) => {
-            const trks: { [key: string]: VesselTrack } = {}
-            Object.entries(d).forEach((i: [Context, LatLngTuple[]]) => {
-              trks[i[0]] = {
+          .then((tc: TrackCollection) => {
+            const trks = Object.entries(tc).reduce<AllTracksResult>((acc, [context, track]) => {
+              acc[context] = {
                 type: 'MultiLineString',
-                coordinates: [i[1]],
+                coordinates: [track],
               }
-            })
+              return acc
+            }, {})
             res.json(trks)
           })
           .catch(() => {

--- a/module/src/index.ts
+++ b/module/src/index.ts
@@ -15,7 +15,7 @@
 
 import { Request, RequestHandler, Response, Router } from 'express'
 import { Tracks as Tracks_, TrackAccumulator as TrackAccumulator_, TracksConfig } from './tracks'
-import { Context, LatLngTuple, Position, VesselCollection, QueryParameters } from './types'
+import { Context, LatLngTuple, Position, TrackCollection, QueryParameters } from './types'
 import { validateParameters } from './utils'
 
 export interface ContextPosition {
@@ -115,7 +115,7 @@ export default function ThePlugin(app: App): Plugin {
         app.debug('** params **', params)
         tracks
           ?.getAll(params, getVesselPosition())
-          .then((d: VesselCollection) => {
+          .then((d: TrackCollection) => {
             const trks: { [key: string]: VesselTrack } = {}
             Object.entries(d).forEach((i: [Context, LatLngTuple[]]) => {
               trks[i[0]] = {

--- a/module/src/index.ts
+++ b/module/src/index.ts
@@ -15,14 +15,17 @@
 
 import { Request, RequestHandler, Response, Router } from 'express'
 import { Tracks as Tracks_, TrackAccumulator as TrackAccumulator_, TracksConfig } from './tracks'
-import { Context, LatLngTuple } from './types'
+import { Context, LatLngTuple, Position, VesselCollection, QueryParameters } from './types'
+import { validateParameters } from './utils'
 
 export interface ContextPosition {
   context: Context
-  value: {
-    latitude: number
-    longitude: number
-  }
+  value: Position
+}
+
+interface VesselTrack {
+  type: string
+  coordinates: Array<Array<LatLngTuple>>
 }
 
 interface App {
@@ -38,6 +41,7 @@ interface App {
       onValue: (cb: (x: any) => void) => () => void
     }
   }
+  getSelfPath: (path: string) => void
 }
 
 interface Plugin {
@@ -56,6 +60,11 @@ export default function ThePlugin(app: App): Plugin {
   let onStop: (() => void)[] = []
   let tracks: Tracks_ | undefined = undefined
 
+  function getVesselPosition(): Position {
+    const p: any = app.getSelfPath('navigation.position')
+    return p && p.value ? p.value : null
+  }
+
   return {
     start: function (configuration: TracksConfig) {
       tracks = new Tracks_(configuration, app.debug)
@@ -63,7 +72,7 @@ export default function ThePlugin(app: App): Plugin {
         app.streambundle
           .getBus('navigation.position')
           .onValue((update: ContextPosition): void =>
-            tracks?.newPosition(update.context, [update.value.latitude, update.value.longitude]),
+            tracks?.newPosition(update.context, [update.value.longitude, update.value.latitude]),
           ),
       )
       const pruneInterval = setInterval(tracks.prune.bind(tracks, 5 * 60 * 1000), 60 * 1000)
@@ -99,6 +108,31 @@ export default function ThePlugin(app: App): Plugin {
           })
       }
       router.get('/vessels/:vesselId/track', trackHandler.bind(this))
+
+      // return all / filtered vessel tracks
+      const allTracksHandler: RequestHandler = (req: Request, res: Response) => {
+        const params: QueryParameters = validateParameters(req.query)
+        app.debug('** params **', params)
+        tracks
+          ?.getAll(params, getVesselPosition())
+          .then((d: VesselCollection) => {
+            const trks: { [key: string]: VesselTrack } = {}
+            Object.entries(d).forEach((i: [Context, LatLngTuple[]]) => {
+              trks[i[0]] = {
+                type: 'MultiLineString',
+                coordinates: [i[1]],
+              }
+            })
+            res.json(trks)
+          })
+          .catch(() => {
+            res.status(404)
+            res.json({ message: `No track available for vessels.` })
+          })
+      }
+      router.get('/tracks', allTracksHandler.bind(this))
+      router.get('/tracks/*', allTracksHandler.bind(this))
+
       return router
     },
 
@@ -124,6 +158,12 @@ export default function ThePlugin(app: App): Plugin {
           title: 'Maximum idle time (seconds)',
           description: 'Tracks with no updates longer than this are removed',
           default: 600,
+        },
+        maxRadius: {
+          type: 'number',
+          title: 'Maximum Radius (meters) ',
+          description: 'Include only vessels with position within this range. 0= all vessels',
+          default: 50000,
         },
       },
     },

--- a/module/src/tracks.ts
+++ b/module/src/tracks.ts
@@ -1,6 +1,6 @@
 import { BehaviorSubject, combineLatest, ConnectableObservable, Observable, ReplaySubject, Subject } from 'rxjs'
 import { map, publishReplay, scan, take, throttleTime } from 'rxjs/operators'
-import { Context, LatLngTuple, Position, QueryParameters, VesselCollection } from './types'
+import { Context, LatLngTuple, Position, QueryParameters, TrackCollection } from './types'
 import { distanceTo, inBounds, latLonTupleToPosition, bboxDateLineAlign } from './utils'
 
 interface tracksMap {
@@ -59,8 +59,8 @@ export class Tracks {
   }
 
   // Return all / filtered vessels and their tracks
-  async getAll(params?: QueryParameters, position?: Position): Promise<VesselCollection> {
-    const res: VesselCollection = {}
+  async getAll(params?: QueryParameters, position?: Position): Promise<TrackCollection> {
+    const res: TrackCollection = {}
     const keys = Object.keys(this.tracks)
     if (params && params.bbox) {
       // align bbox values for inBounds test

--- a/module/src/types.ts
+++ b/module/src/types.ts
@@ -1,3 +1,21 @@
 export type Context = string
 
 export type LatLngTuple = [number, number]
+
+export interface Position {
+  latitude: number
+  longitude: number
+}
+
+export interface VesselCollection {
+  [key: string]: LatLngTuple[]
+}
+
+export interface GeoBounds {
+  ne: LatLngTuple
+  sw: LatLngTuple
+}
+
+export interface QueryParameters {
+  [key: string]: any
+}

--- a/module/src/types.ts
+++ b/module/src/types.ts
@@ -1,6 +1,7 @@
 export type Context = string
 
 export type LatLngTuple = [number, number]
+export type LngLatTuple = [number, number]
 
 export interface Position {
   latitude: number
@@ -17,10 +18,17 @@ export interface GeoBounds {
 }
 
 export interface QueryParameters {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any
 }
 
 export interface TrackParams {
   bbox: GeoBounds | null
   radius: number | null
+}
+
+export interface Debug {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (...args: any): any
+  enabled: boolean
 }

--- a/module/src/types.ts
+++ b/module/src/types.ts
@@ -7,7 +7,7 @@ export interface Position {
   longitude: number
 }
 
-export interface VesselCollection {
+export interface TrackCollection {
   [key: string]: LatLngTuple[]
 }
 
@@ -18,4 +18,9 @@ export interface GeoBounds {
 
 export interface QueryParameters {
   [key: string]: any
+}
+
+export interface TrackParams {
+  bbox: GeoBounds | null
+  radius: number | null
 }

--- a/module/src/utils.test.ts
+++ b/module/src/utils.test.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai'
+import { createInBounds } from './utils'
+
+describe('inBounds', () => {
+  it('works for bounds', () => {
+    const inBounds = createInBounds({ sw: [-10, -10], ne: [10, 175] })
+    expect(inBounds([-11, 176])).to.be.false
+    expect(inBounds([-9, 174])).to.be.true
+    expect(inBounds([-9, 176])).to.be.false
+    expect(inBounds([+9, -11])).to.be.false
+    expect(inBounds([+9, -10])).to.be.true
+  })
+  it('works for bounds crossing dateline', () => {
+    const inBounds = createInBounds({ sw: [-10, 175], ne: [10, -175] })
+    expect(inBounds([-11, 176])).to.be.false
+    expect(inBounds([-9, 176])).to.be.true
+    expect(inBounds([-9, -176])).to.be.true
+    expect(inBounds([-9, -174])).to.be.false
+    expect(inBounds([+9, -174])).to.be.false
+    expect(inBounds([+9, -176])).to.be.true
+    expect(inBounds([+11, -176])).to.be.false
+  })
+})

--- a/module/src/utils.ts
+++ b/module/src/utils.ts
@@ -1,6 +1,6 @@
 // ** utility functions **
 
-import { LatLngTuple, GeoBounds, Position, QueryParameters } from './types'
+import { LatLngTuple, GeoBounds, Position, QueryParameters, TrackParams } from './types'
 
 // ** Align bounding box valjues to reflect spanning the date line
 export function bboxDateLineAlign(bounds: GeoBounds) {
@@ -32,8 +32,9 @@ export function inBounds(position: LatLngTuple, bounds: GeoBounds): boolean {
 }
 
 // validate query parameters
-export function validateParameters(params: QueryParameters) {
+export function validateParameters(params: QueryParameters): TrackParams {
   // bounding box lon1,lat1,lon2,lat2
+  let bbox: GeoBounds | null = null
   if (typeof params.bbox !== 'undefined') {
     const b: number[] = params.bbox
       .split(',')
@@ -45,13 +46,15 @@ export function validateParameters(params: QueryParameters) {
       .filter((i: number) => {
         if (typeof i === 'number') return i
       })
-    params.bbox = b.length == 4 ? { sw: [b[0], b[1]], ne: [b[2], b[3]] } : null
+    bbox = b.length == 4 ? { sw: [b[0], b[1]], ne: [b[2], b[3]] } : null
   }
+
+  let radius: number | null = null
   // radius in meters
   if (typeof params.radius !== 'undefined') {
-    params.radius = !isNaN(params.radius) ? parseFloat(params.radius) : null
+    radius = !isNaN(params.radius) ? parseFloat(params.radius) : null
   }
-  return params
+  return { bbox, radius }
 }
 
 //** Calculate the distance between two points in meters

--- a/module/src/utils.ts
+++ b/module/src/utils.ts
@@ -1,0 +1,87 @@
+// ** utility functions **
+
+import { LatLngTuple, GeoBounds, Position, QueryParameters } from './types'
+
+// ** Align bounding box valjues to reflect spanning the date line
+export function bboxDateLineAlign(bounds: GeoBounds) {
+  if (bounds.sw[0] > 0 && bounds.ne[0] < 0) {
+    bounds.ne[0] = 360 + bounds.ne[0]
+  }
+  return bounds
+}
+
+// ** check position is in bounds
+export function inBounds(position: LatLngTuple, bounds: GeoBounds): boolean {
+  if (position && typeof position[0] == 'number' && typeof position[1] == 'number') {
+    const dlPosition = [position[0], position[1]]
+    if (bounds.ne[0] > 180) {
+      // date line spanned?
+      if (dlPosition[0] < 0) {
+        dlPosition[0] = 360 + dlPosition[0]
+      }
+    }
+    return dlPosition[1] >= bounds.sw[1] &&
+      dlPosition[1] <= bounds.ne[1] &&
+      dlPosition[0] >= bounds.sw[0] &&
+      dlPosition[0] <= bounds.ne[0]
+      ? true
+      : false
+  } else {
+    return false
+  }
+}
+
+// validate query parameters
+export function validateParameters(params: QueryParameters) {
+  // bounding box lon1,lat1,lon2,lat2
+  if (typeof params.bbox !== 'undefined') {
+    const b: number[] = params.bbox
+      .split(',')
+      .map((i: string | number) => {
+        if (!isNaN(i as number)) {
+          return parseFloat(i as string)
+        }
+      })
+      .filter((i: number) => {
+        if (typeof i === 'number') return i
+      })
+    params.bbox = b.length == 4 ? { sw: [b[0], b[1]], ne: [b[2], b[3]] } : null
+  }
+  // radius in meters
+  if (typeof params.radius !== 'undefined') {
+    params.radius = !isNaN(params.radius) ? parseFloat(params.radius) : null
+  }
+  return params
+}
+
+//** Calculate the distance between two points in meters
+export function distanceTo(srcpt: Position, destpt: Position) {
+  const Rk = 6371 // mean radius of the earth (km) at 39 degrees from the equator
+
+  // convert coordinates to radians
+  const lat1 = degreesToRadians(srcpt.latitude)
+  const lon1 = degreesToRadians(srcpt.longitude)
+  const lat2 = degreesToRadians(destpt.latitude)
+  const lon2 = degreesToRadians(destpt.longitude)
+
+  // find the differences between the coordinates
+  const dlat = lat2 - lat1
+  const dlon = lon2 - lon1
+
+  //** calculate **
+  const a = Math.pow(Math.sin(dlat / 2), 2) + Math.cos(lat1) * Math.cos(lat2) * Math.pow(Math.sin(dlon / 2), 2)
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  const dk = c * Rk * 1000 // great circle distance in m
+  return dk
+}
+
+const degreesToRadians = (value: number) => {
+  return (Math.PI / 180) * value
+}
+
+export function latLonTupleToPosition(value: LatLngTuple): Position {
+  return {
+    longitude: value[0],
+    latitude: value[1],
+  }
+}

--- a/module/src/utils.ts
+++ b/module/src/utils.ts
@@ -1,37 +1,28 @@
-// ** utility functions **
+import { LatLngTuple, GeoBounds, QueryParameters, TrackParams, Debug } from './types'
 
-import { LatLngTuple, GeoBounds, Position, QueryParameters, TrackParams } from './types'
+const LAT = 0
+const LNG = 1
 
-// ** Align bounding box valjues to reflect spanning the date line
-export function bboxDateLineAlign(bounds: GeoBounds) {
-  if (bounds.sw[0] > 0 && bounds.ne[0] < 0) {
-    bounds.ne[0] = 360 + bounds.ne[0]
+// create function to check position against GeoBounds
+export function createInBounds(bounds: GeoBounds): (position: LatLngTuple | null) => boolean {
+  const minLat = bounds.sw[LAT]
+  const maxLat = bounds.ne[LAT]
+  if (minLat > maxLat) {
+    throw new Error(`Bounding box south must be <=  north, got ${JSON.stringify(bounds)}`)
   }
-  return bounds
-}
+  const minLng = bounds.sw[LNG]
+  const maxLng = (bounds.sw[LNG] > bounds.ne[LNG] ? 360 : 0) + bounds.ne[LNG]
 
-// ** check position is in bounds
-export function inBounds(position: LatLngTuple, bounds: GeoBounds): boolean {
-  if (position && typeof position[0] == 'number' && typeof position[1] == 'number') {
-    const dlPosition = [position[0], position[1]]
-    if (bounds.ne[0] > 180) {
-      // date line spanned?
-      if (dlPosition[0] < 0) {
-        dlPosition[0] = 360 + dlPosition[0]
-      }
-    }
-    return dlPosition[1] >= bounds.sw[1] &&
-      dlPosition[1] <= bounds.ne[1] &&
-      dlPosition[0] >= bounds.sw[0] &&
-      dlPosition[0] <= bounds.ne[0]
-      ? true
-      : false
-  } else {
-    return false
+  return (p) => {
+    return (
+      p !== null &&
+      p[LAT] >= minLat &&
+      p[LAT] <= maxLat &&
+      ((p[LNG] >= minLng && p[LNG] <= maxLng) || (p[LNG] + 360 >= minLng && p[LNG] + 360 <= maxLng))
+    )
   }
 }
 
-// validate query parameters
 export function validateParameters(params: QueryParameters): TrackParams {
   // bounding box lon1,lat1,lon2,lat2
   let bbox: GeoBounds | null = null
@@ -57,34 +48,59 @@ export function validateParameters(params: QueryParameters): TrackParams {
   return { bbox, radius }
 }
 
-//** Calculate the distance between two points in meters
-export function distanceTo(srcpt: Position, destpt: Position) {
+//Create function to calculate distance to a point
+export function createDistanceTo([lat1d, lon1d]: LatLngTuple, debug?: Debug): (d: LatLngTuple | null) => number {
   const Rk = 6371 // mean radius of the earth (km) at 39 degrees from the equator
 
   // convert coordinates to radians
-  const lat1 = degreesToRadians(srcpt.latitude)
-  const lon1 = degreesToRadians(srcpt.longitude)
-  const lat2 = degreesToRadians(destpt.latitude)
-  const lon2 = degreesToRadians(destpt.longitude)
+  const lat1 = degreesToRadians(lat1d)
+  const lon1 = degreesToRadians(lon1d)
 
-  // find the differences between the coordinates
-  const dlat = lat2 - lat1
-  const dlon = lon2 - lon1
+  return (dest) => {
+    if (!dest) {
+      return Number.MAX_SAFE_INTEGER
+    }
+    const [lat2d, lon2d] = dest
+    const lat2 = degreesToRadians(lat2d)
+    const lon2 = degreesToRadians(lon2d)
 
-  //** calculate **
-  const a = Math.pow(Math.sin(dlat / 2), 2) + Math.cos(lat1) * Math.cos(lat2) * Math.pow(Math.sin(dlon / 2), 2)
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
-  const dk = c * Rk * 1000 // great circle distance in m
-  return dk
+    // find the differences between the coordinates
+    const dlat = lat2 - lat1
+    const dlon = lon2 - lon1
+
+    //** calculate **
+    const a = Math.pow(Math.sin(dlat / 2), 2) + Math.cos(lat1) * Math.cos(lat2) * Math.pow(Math.sin(dlon / 2), 2)
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+    const dk = c * Rk * 1000 // great circle distance in m
+    if (debug && debug.enabled) {
+      debug(`${[lat2d, lon2d]} => ${dk}`)
+    }
+    return dk
+  }
 }
 
 const degreesToRadians = (value: number) => {
   return (Math.PI / 180) * value
 }
 
-export function latLonTupleToPosition(value: LatLngTuple): Position {
-  return {
-    longitude: value[0],
-    latitude: value[1],
+function lastPoint(track: LatLngTuple[]): LatLngTuple | null {
+  return track.length ? track[track.length - 1] : null
+}
+
+export function createMatcher(
+  params: TrackParams,
+  selfPosition?: LatLngTuple,
+  debug?: Debug,
+): (track: LatLngTuple[]) => boolean {
+  if (params.bbox) {
+    const inBounds = createInBounds(params.bbox)
+    return (track: LatLngTuple[]) => inBounds(lastPoint(track))
+  } else if (params.radius !== null) {
+    if (!selfPosition) {
+      throw new Error('No self position to calculate radius values')
+    }
+    const distanceFromSelf = createDistanceTo(selfPosition, debug)
+    return (track: LatLngTuple[]) => distanceFromSelf(lastPoint(track)) < (params.radius as number)
   }
+  return () => true
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@signalk/tracks": "^1.0.1"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.5",
     "prettier": "2.2.1"
   }
 }


### PR DESCRIPTION
Replaces #4. Fixes #3.

Fixes the order of coordinates in response's GeoJSON MultilineStrings: the code uses internally LatLngTuple, but GeoJSON coordinates are `[longitude, latitude]`.

Adds /tracks route handler that returns tracks for ALL vessels, with optional bbox and radius query parameters as well as a default max radius.