### PR TITLE
fix: config param handling

### DIFF
--- a/module/src/tracks.ts
+++ b/module/src/tracks.ts
@@ -15,9 +15,7 @@ interface VesselTrack {
 export interface TracksConfig {
   resolution: number
   pointsToKeep: number
-  maxAge: number
   fetchInitialTrack?: boolean
-  maxRadius: number
 }
 
 export class Tracks {
@@ -25,6 +23,7 @@ export class Tracks {
   debug: Debug
   config: TracksConfig
   constructor(config: TracksConfig, debug: Debug) {
+    debug(JSON.stringify(config))
     this.config = config
     this.debug = debug
   }


### PR DESCRIPTION
Missing parameters, notably points to keep, were not handled
at all. This change makes defaults handling explicit and the
same defaults are used in schema and program logic. Numeric
parameters are no integers in schema.

Also some types cleanup, as the Tracks class does not use
maxAge and radius.