### PR TITLE
fix: resolve self alias to selfContext in track handler

### DIFF
--- a/module/src/index.ts
+++ b/module/src/index.ts
@@ -16,7 +16,7 @@
 import { Request, RequestHandler, Response, Router } from 'express'
 import { Tracks as Tracks_, TrackAccumulator as TrackAccumulator_, TracksConfig } from './tracks'
 import { Context, Debug, LatLngTuple, LngLatTuple, Position, TrackCollection } from './types'
-import { validateParameters } from './utils'
+import { resolveContext, validateParameters } from './utils'
 
 export interface ContextPosition {
   context: Context
@@ -308,8 +308,9 @@ export default function ThePlugin(app: App): Plugin {
           notAvailable(res)
           return
         }
+        const context = resolveContext(req.params.vesselId, app.selfContext)
         tracks
-          ?.get(`vessels.${req.params.vesselId}`)
+          ?.get(context)
           .then((coordinates: LatLngTuple[]) => {
             res.json({
               type: 'MultiLineString',
@@ -318,7 +319,7 @@ export default function ThePlugin(app: App): Plugin {
           })
           .catch(() => {
             res.status(404)
-            res.json({ message: `No track available for vessels.${req.params.vesselId}` })
+            res.json({ message: `No track available for ${context}` })
           })
       }
       router.get('/vessels/:vesselId/track', trackHandler.bind(this))

--- a/module/src/utils.test.ts
+++ b/module/src/utils.test.ts
@@ -1,5 +1,23 @@
 import { expect } from 'chai'
-import { createInBounds } from './utils'
+import { createInBounds, resolveContext } from './utils'
+
+const SELF = 'vessels.urn:mrn:imo:mmsi:123456789'
+
+describe('resolveContext', () => {
+  it('resolves the self alias to the self context', () => {
+    expect(resolveContext('self', SELF)).to.equal(SELF)
+    expect(resolveContext('vessels.self', SELF)).to.equal(SELF)
+  })
+  it('qualifies a bare vessel id', () => {
+    expect(resolveContext('urn:mrn:imo:mmsi:987654321', SELF)).to.equal('vessels.urn:mrn:imo:mmsi:987654321')
+  })
+  it('leaves an already qualified context alone', () => {
+    expect(resolveContext('vessels.urn:mrn:imo:mmsi:987654321', SELF)).to.equal('vessels.urn:mrn:imo:mmsi:987654321')
+  })
+  it('falls back to the literal id when selfContext is unavailable', () => {
+    expect(resolveContext('self', undefined)).to.equal('vessels.self')
+  })
+})
 
 describe('inBounds', () => {
   it('works for bounds', () => {

--- a/module/src/utils.ts
+++ b/module/src/utils.ts
@@ -89,6 +89,17 @@ function lastPoint(track: LatLngTuple[]): LatLngTuple | null {
   return track.length ? track[track.length - 1] : null
 }
 
+// Positions are accumulated under the context carried by the delta, which for
+// the own vessel is always the fully qualified context (vessels.urn:mrn:...),
+// never the literal `vessels.self`. Resolve the `self` alias the rest of the
+// Signal K HTTP API accepts so a lookup for it can hit.
+export function resolveContext(vesselId: string, selfContext?: string): string {
+  if ((vesselId === 'self' || vesselId === 'vessels.self') && selfContext) {
+    return selfContext
+  }
+  return vesselId.startsWith('vessels.') ? vesselId : `vessels.${vesselId}`
+}
+
 export function createMatcher(
   params: TrackParams,
   selfPosition?: LatLngTuple,


### PR DESCRIPTION
Fixes #18.

`GET /signalk/v1/api/vessels/self/track` always 404s, even when the plugin is running normally and accumulating points. The same request with an explicit context (`/vessels/urn:mrn:imo:mmsi:XXX/track`) returns the track fine.

The position listener stores points under the context carried by the delta, which for the own vessel is always the fully qualified context — never the literal `vessels.self`. The handler built its lookup key straight from the URL parameter, so the `self` request looked up a key that by construction can never exist and fell through to the 404 branch.

This resolves the alias against `app.selfContext` before the lookup, the way the rest of the Signal K HTTP API treats `self`. `app.selfContext` is already used elsewhere in the plugin (`bootstrapSelfTrack`), so no new server surface is relied on.

The 404 message now reports the resolved context rather than echoing the raw parameter, so a genuine "no points accumulated yet" is distinguishable from an alias that failed to resolve — the ambiguity that made this look like a data-collection problem in #18.

Worth noting this is easy to misdiagnose: the data was never missing, only unreachable through the documented endpoint, so any client using the standard `self` path (TrackViewer-SK, Freeboard-SK) shows an empty own-vessel track while everything looks healthy server-side.

Tested: `npm test` in `module/` — 6 passing, including 4 new `resolveContext` cases (self alias, bare vessel id, already-qualified context, and the no-`selfContext` fallback). `npx tsc` builds clean.

Two pre-existing issues in the repo, untouched here and worth separate PRs: `ts-node@9` can't drive `typescript@4.9` (`npm test` fails on a clean checkout with a `resolveTypeReferenceDirective` signature error until ts-node is upgraded to 10), and `src/index.ts` doesn't satisfy `prettier --check` on main. I formatted only the files I added to.
