### PR TITLE
Serve /self/track and honour the time-window query parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "rxjs": "^7.8.2"
+        "rxjs": "^7.8.2",
+        "typebox": "^1.3.11"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -2471,14 +2472,11 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
+      "license": "MIT"
     },
     "node_modules/cookiejar": {
       "version": "2.1.4",
@@ -3003,13 +3001,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/express/node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
@@ -3722,16 +3713,16 @@
       }
     },
     "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -4350,19 +4341,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/send/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/serve-static": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
@@ -4587,6 +4565,19 @@
         "node": ">=14.18.0"
       }
     },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/supertest": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
@@ -4600,6 +4591,16 @@
       },
       "engines": {
         "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {
@@ -4747,6 +4748,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typebox": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.11.tgz",
+      "integrity": "sha512-tZGKIS02Opbh4EYMmAEVuXl+y3EQJ9ZlkitLZ1CmFCY4ZOqr/xWR9dDSCFmIjNDICGMWkOqMh6WxGTyRXqcSGQ==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "rxjs": "^7.8.2"
+    "rxjs": "^7.8.2",
+    "typebox": "^1.3.11"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/harness.test-utils.ts
+++ b/src/harness.test-utils.ts
@@ -20,8 +20,20 @@ type PositionListener = (update: ContextPosition) => void
 
 export interface TestHarness {
   app: Express
-  /** Feed a position delta as the streambundle would. */
-  emit: (context: string, position: LatLngTuple) => void
+  /**
+   * Feed a position delta as the streambundle would. `timestamp` dates the
+   * point, so time-window queries can be tested without faking the clock.
+   *
+   * Note `throttleTime` thins on the leading edge against the wall clock, so a
+   * synchronous burst yields a single point regardless of the timestamps given.
+   * Use `seedTrack` to install a back-dated track instead.
+   */
+  emit: (context: string, position: LatLngTuple, timestamp?: number) => void
+  /**
+   * Install a track with explicit timestamps, bypassing the throttled bus. This
+   * is the entry point the History API bootstrap uses.
+   */
+  seedTrack: (context: string, positions: LatLngTuple[], timestamps: number[]) => void
   /** Self position as reported by `getSelfPath`, used for radius filtering. */
   setSelfPosition: (position: LatLngTuple | undefined) => void
   stop: () => void
@@ -79,10 +91,17 @@ export function createHarness(options: HarnessOptions = {}): TestHarness {
 
   return {
     app: expressApp,
-    emit: (context, position) => {
+    emit: (context, position, timestamp) => {
       for (const cb of listeners) {
-        cb({ context, value: { latitude: position[0], longitude: position[1] } })
+        cb({
+          context,
+          value: { latitude: position[0], longitude: position[1] },
+          ...(timestamp === undefined ? {} : { timestamp: new Date(timestamp).toISOString() }),
+        })
       }
+    },
+    seedTrack: (context, positions, timestamps) => {
+      plugin.getTracks()?.initialTrack(context, positions, timestamps)
     },
     setSelfPosition: (position) => {
       selfPosition = position

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,12 +15,16 @@
 
 import type { Request, RequestHandler, Response, Router } from 'express'
 import { Tracks as Tracks_ } from './tracks.js'
+import { parseTrackQuery, thin, TimeWindowError } from './timeWindow.js'
+import type { TrackQuery } from './timeWindow.js'
 import type { Context, Debug, LatLngTuple, LngLatTuple, Position, TrackCollection } from './types.js'
 import { resolveContext, validateParameters } from './utils.js'
 
 export interface ContextPosition {
   context: Context
   value: Position
+  /** ISO-8601 time the value was recorded, as carried by the Signal K delta. */
+  timestamp?: string
 }
 
 interface AllTracksResult {
@@ -73,6 +77,14 @@ interface Plugin {
   name: string
   description: string
   schema: Record<string, unknown>
+  /**
+   * The live accumulator, or undefined before `start()`.
+   *
+   * Exposed so a track can be installed or inspected without going through the
+   * position bus, which throttles against the wall clock. The Signal K server
+   * does not use this.
+   */
+  getTracks: () => Tracks_ | undefined
 }
 
 interface TracksPluginConfig {
@@ -190,12 +202,17 @@ async function bootstrapSelfTrack(app: App, tracks: Tracks_, config: TracksPlugi
 
       if (response?.data && response.data.length > 0) {
         // History API returns [timestamp, [lon, lat]]; flip to [lat, lng] for LatLngTuple.
-        const positions: LatLngTuple[] = response.data
-          .filter(isHistoryPositionRow)
-          .map(([, [lon, lat]]): LatLngTuple => [lat, lon])
+        const rows = response.data.filter(isHistoryPositionRow)
+        const positions: LatLngTuple[] = rows.map(([, [lon, lat]]): LatLngTuple => [lat, lon])
+        // Carry the recorded times through so bootstrapped points answer
+        // time-window queries rather than looking infinitely old.
+        const timestamps = rows.map(([time]) => {
+          const parsed = Date.parse(time)
+          return Number.isNaN(parsed) ? 0 : parsed
+        })
 
         if (positions.length > 0) {
-          tracks.initialTrack(app.selfContext, positions)
+          tracks.initialTrack(app.selfContext, positions, timestamps)
           debug(
             `Track bootstrap complete: loaded ${positions.length} positions for self ` +
               `(${timespanMinutes} min window) on attempt ${attempt}`,
@@ -265,7 +282,14 @@ export default function ThePlugin(app: App): Plugin {
       onStop.push(
         app.streambundle.getBus('navigation.position').onValue((update: ContextPosition): void => {
           if (!update.value || update.value.latitude == null || update.value.longitude == null) return
-          tracks?.newPosition(update.context, [update.value.latitude, update.value.longitude])
+          // Prefer the delta's own timestamp so a replayed or delayed update is
+          // filed at the time it was recorded, not the time it arrived.
+          const recorded = update.timestamp === undefined ? undefined : Date.parse(update.timestamp)
+          tracks?.newPosition(
+            update.context,
+            [update.value.latitude, update.value.longitude],
+            recorded !== undefined && !Number.isNaN(recorded) ? recorded : undefined,
+          )
         }),
       )
       const theMaxAge = toNumber(maxAge) ?? DEFAULT_MAX_AGE
@@ -295,26 +319,46 @@ export default function ThePlugin(app: App): Plugin {
     },
 
     signalKApiRoutes: function (router: Router) {
-      const trackHandler: RequestHandler = (req: Request, res: Response) => {
-        if (!tracks) {
-          notAvailable(res)
-          return
-        }
-        const context = resolveContext(String(req.params.vesselId), app.selfContext)
-        tracks
-          .get(context)
-          .then((coordinates: LatLngTuple[]) => {
-            res.json({
-              type: 'MultiLineString',
-              coordinates: [coordinates.map(toLngLat)],
+      const singleTrackHandler =
+        (contextOf: (req: Request) => string): RequestHandler =>
+        (req: Request, res: Response) => {
+          if (!tracks) {
+            notAvailable(res)
+            return
+          }
+          const context = contextOf(req)
+          let query: TrackQuery
+          try {
+            query = parseTrackQuery(req.query)
+          } catch (err) {
+            res.status(400)
+            res.json({ message: err instanceof TimeWindowError ? err.message : 'Invalid query parameters' })
+            return
+          }
+          tracks
+            .getTimed(context, query.window)
+            .then((points) => {
+              res.json({
+                type: 'MultiLineString',
+                coordinates: [thin(points, query.resolution).map(({ position }) => toLngLat(position))],
+              })
             })
-          })
-          .catch(() => {
-            res.status(404)
-            res.json({ message: `No track available for ${context}` })
-          })
-      }
+            .catch(() => {
+              res.status(404)
+              res.json({ message: `No track available for ${context}` })
+            })
+        }
+
+      const trackHandler = singleTrackHandler((req) => resolveContext(String(req.params.vesselId), app.selfContext))
       router.get('/vessels/:vesselId/track', trackHandler)
+
+      // Freeboard-SK requests the own vessel's trail here rather than at
+      // /vessels/self/track. Plugin routes are mounted before the v1 REST
+      // interface, so this takes precedence over the data-tree walker.
+      router.get(
+        '/self/track',
+        singleTrackHandler(() => app.selfContext),
+      )
 
       // return all / filtered vessel tracks
       const allTracksHandler: RequestHandler = (req: Request, res: Response) => {
@@ -323,8 +367,16 @@ export default function ThePlugin(app: App): Plugin {
           notAvailable(res)
           return
         }
+        let query: TrackQuery
+        try {
+          query = parseTrackQuery(req.query)
+        } catch (err) {
+          res.status(400)
+          res.json({ message: err instanceof TimeWindowError ? err.message : 'Invalid query parameters' })
+          return
+        }
         tracks
-          .getFilteredTracks(validateParameters(req.query, defaultMaxRadius), getVesselPosition(), app.debug)
+          .getFilteredTracks(validateParameters(req.query, defaultMaxRadius), getVesselPosition(), app.debug, query)
           .then((tc: TrackCollection) => {
             const trks = Object.entries(tc).reduce<AllTracksResult>((acc, [context, track]) => {
               acc[context] = {
@@ -347,6 +399,8 @@ export default function ThePlugin(app: App): Plugin {
 
       return router
     },
+
+    getTracks: () => tracks,
 
     id: 'tracks',
     name: 'Tracks',

--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -116,23 +116,23 @@ describe('when the plugin has been stopped', () => {
   })
 })
 
-// ── Gaps documented by RFC #2504 / Freeboard-SK compatibility ───────────────
-// Freeboard-SK requests `/self/track?timespan=1h&resolution=N&timespanOffset=N`.
-// Verified against a live server: the route 404s and the parameters are ignored.
-// These tests pin today's behaviour so the fix is visible as a diff.
-describe('Freeboard-SK compatibility gaps', () => {
-  it('does not serve /self/track', async () => {
+// ── Freeboard-SK compatibility ─────────────────────────────────────────────
+// These pinned the gap before it was fixed: /self/track 404'd and the time
+// parameters were ignored. Time-window behaviour itself is covered in
+// selfTrack.test.ts; this just holds the route open.
+describe('Freeboard-SK compatibility', () => {
+  it('serves /self/track', async () => {
     const h = withTracks([SELF_CONTEXT, [60.1, 24.9]])
 
-    await request(h.app).get(`${API}/self/track`).expect(404)
+    const res = await request(h.app).get(`${API}/self/track`).expect(200)
+
+    expect(res.body.type).toBe('MultiLineString')
+    expect(res.body.coordinates[0][0]).toEqual([24.9, 60.1])
   })
 
-  it('ignores timespan and resolution', async () => {
-    const h = withTracks([SELF_CONTEXT, [60.1, 24.9]], [SELF_CONTEXT, [60.2, 24.8]])
+  it('accepts the timespan and resolution parameters', async () => {
+    const h = withTracks([SELF_CONTEXT, [60.1, 24.9]])
 
-    const all = await request(h.app).get(`${API}/vessels/${SELF_ID}/track`).expect(200)
-    const windowed = await request(h.app).get(`${API}/vessels/${SELF_ID}/track?timespan=1h&resolution=60`).expect(200)
-
-    expect(windowed.body.coordinates[0]).toEqual(all.body.coordinates[0])
+    await request(h.app).get(`${API}/vessels/${SELF_ID}/track?timespan=1h&resolution=60`).expect(200)
   })
 })

--- a/src/selfTrack.test.ts
+++ b/src/selfTrack.test.ts
@@ -1,0 +1,165 @@
+import request from 'supertest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createHarness, SELF_CONTEXT } from './harness.test-utils.js'
+import type { TestHarness } from './harness.test-utils.js'
+import type { LatLngTuple } from './types.js'
+
+const API = '/signalk/v1/api'
+const HOUR = 60 * 60 * 1000
+
+let harness: TestHarness | undefined
+
+afterEach(() => {
+  harness?.stop()
+  harness = undefined
+})
+
+/**
+ * A self track spanning three days, one point per hour, so time-window queries
+ * have something to select from.
+ *
+ * The points are installed through `Tracks.initialTrack` rather than fed to the
+ * position bus: `throttleTime` thins the bus against the wall clock, so a
+ * synchronous burst would collapse to a single point whatever timestamps it
+ * carried. This is the same entry point the History API bootstrap uses.
+ */
+function selfTrackOverTime() {
+  const now = Date.now()
+  const positions: LatLngTuple[] = []
+  const timestamps: number[] = []
+  for (let hoursAgo = 72; hoursAgo >= 0; hoursAgo--) {
+    positions.push([60 + hoursAgo / 1000, 24])
+    // Sit a second inside each hour boundary. The handler reads its own
+    // Date.now() milliseconds later, so a point dated exactly on a boundary
+    // would fall just outside the window and make these tests flaky.
+    timestamps.push(now - hoursAgo * HOUR - 1000)
+  }
+  const h = createHarness({ selfPosition: [60, 24] })
+  h.seedTrack(SELF_CONTEXT, positions, timestamps)
+  harness = h
+  return { h, now }
+}
+
+const pointCount = (body: { coordinates: unknown[][] }) => body.coordinates[0]?.length ?? 0
+
+describe('GET /self/track', () => {
+  it('serves the own vessel track', async () => {
+    const { h } = selfTrackOverTime()
+
+    const res = await request(h.app).get(`${API}/self/track`).expect(200)
+
+    expect(res.body.type).toBe('MultiLineString')
+    expect(pointCount(res.body)).toBe(73)
+  })
+
+  it('404s when the own vessel has no track', async () => {
+    harness = createHarness({ selfPosition: [60, 24] })
+
+    await request(harness.app).get(`${API}/self/track`).expect(404)
+  })
+})
+
+describe('time windows', () => {
+  it('narrows to the last hour with the Freeboard timespan parameter', async () => {
+    const { h } = selfTrackOverTime()
+
+    const res = await request(h.app).get(`${API}/self/track?timespan=1h`).expect(200)
+
+    // hourly points, so a one-hour window holds the most recent one
+    expect(pointCount(res.body)).toBe(1)
+  })
+
+  it('honours timespanOffset as hours back from now', async () => {
+    const { h } = selfTrackOverTime()
+
+    const res = await request(h.app).get(`${API}/self/track?timespan=23h&timespanOffset=1`).expect(200)
+
+    // [now-24h, now-1h): 23 hourly points
+    expect(pointCount(res.body)).toBe(23)
+  })
+
+  it('covers the whole track across the three bands Freeboard requests', async () => {
+    const { h } = selfTrackOverTime()
+
+    const [beyond, next23, last] = await Promise.all([
+      request(h.app).get(`${API}/self/track?timespan=72h&timespanOffset=24`).expect(200),
+      request(h.app).get(`${API}/self/track?timespan=23h&timespanOffset=1`).expect(200),
+      request(h.app).get(`${API}/self/track?timespan=1h`).expect(200),
+    ])
+
+    // The bands are concatenated client-side, so the property that matters is
+    // that they neither drop a point nor return one twice.
+    const bands = [beyond!.body, next23!.body, last!.body] as { coordinates: number[][][] }[]
+    const points = bands.flatMap((b) => b.coordinates[0] ?? []).map((p) => JSON.stringify(p))
+
+    expect(points).toHaveLength(73)
+    expect(new Set(points).size).toBe(73)
+  })
+
+  it('accepts the spec-shaped duration parameter', async () => {
+    const { h } = selfTrackOverTime()
+
+    const res = await request(h.app).get(`${API}/self/track?duration=2h`).expect(200)
+
+    expect(pointCount(res.body)).toBe(2)
+  })
+
+  it('accepts explicit from/to', async () => {
+    const { h, now } = selfTrackOverTime()
+    const from = new Date(now - 3 * HOUR).toISOString()
+    const to = new Date(now - HOUR).toISOString()
+
+    const res = await request(h.app).get(`${API}/self/track?from=${from}&to=${to}`).expect(200)
+
+    expect(pointCount(res.body)).toBe(2)
+  })
+
+  it('rejects an unparseable time with 400 rather than a silent full track', async () => {
+    const { h } = selfTrackOverTime()
+
+    const res = await request(h.app).get(`${API}/self/track?from=yesterday`).expect(400)
+
+    expect(res.body.message).toMatch(/Invalid from/)
+  })
+
+  it('applies to the per-vessel route too', async () => {
+    const { h } = selfTrackOverTime()
+    const id = SELF_CONTEXT.replace('vessels.', '')
+
+    const res = await request(h.app).get(`${API}/vessels/${id}/track?timespan=1h`).expect(200)
+
+    expect(pointCount(res.body)).toBe(1)
+  })
+})
+
+describe('resolution', () => {
+  it('thins the track to the requested spacing', async () => {
+    const { h } = selfTrackOverTime()
+
+    const full = await request(h.app).get(`${API}/self/track`).expect(200)
+    const thinned = await request(h.app).get(`${API}/self/track?resolution=6h`).expect(200)
+
+    expect(pointCount(full.body)).toBe(73)
+    // 72 hours at 6-hour spacing, plus the retained final point
+    expect(pointCount(thinned.body)).toBeLessThan(pointCount(full.body))
+    expect(pointCount(thinned.body)).toBe(13)
+  })
+
+  it('keeps the track extent when thinning', async () => {
+    const { h } = selfTrackOverTime()
+
+    const full = await request(h.app).get(`${API}/self/track`).expect(200)
+    const thinned = await request(h.app).get(`${API}/self/track?resolution=6h`).expect(200)
+
+    expect(thinned.body.coordinates[0][0]).toEqual(full.body.coordinates[0][0])
+    expect(thinned.body.coordinates[0].at(-1)).toEqual(full.body.coordinates[0].at(-1))
+  })
+
+  it('combines a window and a resolution', async () => {
+    const { h } = selfTrackOverTime()
+
+    const res = await request(h.app).get(`${API}/self/track?timespan=24h&resolution=6h`).expect(200)
+
+    expect(pointCount(res.body)).toBe(5)
+  })
+})

--- a/src/timeWindow.test.ts
+++ b/src/timeWindow.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import { parseDuration, parseTrackQuery, thin, TimeWindowError } from './timeWindow.js'
+import type { TimedPosition } from './types.js'
+
+const NOW = Date.parse('2026-08-09T12:00:00Z')
+const HOUR = 60 * 60 * 1000
+
+describe('parseDuration', () => {
+  it('treats a bare number as seconds', () => {
+    expect(parseDuration('30')).toBe(30_000)
+  })
+  it('accepts s, m, h and d suffixes', () => {
+    expect(parseDuration('5s')).toBe(5_000)
+    expect(parseDuration('1m')).toBe(60_000)
+    expect(parseDuration('2h')).toBe(2 * HOUR)
+    expect(parseDuration('1d')).toBe(24 * HOUR)
+  })
+  it('rejects nonsense', () => {
+    expect(() => parseDuration('soon')).toThrow(TimeWindowError)
+    expect(() => parseDuration('')).toThrow(TimeWindowError)
+    expect(() => parseDuration('5y')).toThrow(TimeWindowError)
+  })
+})
+
+describe('parseTrackQuery', () => {
+  it('returns no window when no time parameters are given', () => {
+    expect(parseTrackQuery({}, NOW).window).toBeUndefined()
+  })
+
+  it('resolves from/to', () => {
+    const { window } = parseTrackQuery({ from: '2026-08-09T10:00:00Z', to: '2026-08-09T11:00:00Z' }, NOW)
+    expect(window).toEqual({ from: NOW - 2 * HOUR, to: NOW - HOUR, inclusiveEnd: false })
+  })
+
+  it('defaults to now when only from is given, and includes the newest point', () => {
+    const { window } = parseTrackQuery({ from: '2026-08-09T11:00:00Z' }, NOW)
+    expect(window).toEqual({ from: NOW - HOUR, to: NOW, inclusiveEnd: true })
+  })
+
+  it('rejects an inverted range', () => {
+    expect(() => parseTrackQuery({ from: '2026-08-09T11:00:00Z', to: '2026-08-09T10:00:00Z' }, NOW)).toThrow(
+      TimeWindowError,
+    )
+  })
+
+  it('rejects an unparseable instant', () => {
+    expect(() => parseTrackQuery({ from: 'yesterday' }, NOW)).toThrow(TimeWindowError)
+  })
+
+  it('resolves duration as a window ending now', () => {
+    expect(parseTrackQuery({ duration: '2h' }, NOW).window).toEqual({
+      from: NOW - 2 * HOUR,
+      to: NOW,
+      inclusiveEnd: true,
+    })
+  })
+
+  // Freeboard-SK compatibility: timespanOffset is a bare number of hours back
+  // from now, and timespan is the length of the window ending there.
+  it('resolves the Freeboard timespan/timespanOffset pair', () => {
+    expect(parseTrackQuery({ timespan: '1h' }, NOW).window).toEqual({
+      from: NOW - HOUR,
+      to: NOW,
+      inclusiveEnd: true,
+    })
+    // an offset band ends before now, so it stays half-open and tiles cleanly
+    expect(parseTrackQuery({ timespan: '23h', timespanOffset: '1' }, NOW).window).toEqual({
+      from: NOW - 24 * HOUR,
+      to: NOW - HOUR,
+      inclusiveEnd: false,
+    })
+  })
+
+  it('tiles the three Freeboard bands without gaps or overlap', () => {
+    const beyond24 = parseTrackQuery({ timespan: '24h', timespanOffset: '24' }, NOW).window
+    const next23 = parseTrackQuery({ timespan: '23h', timespanOffset: '1' }, NOW).window
+    const lastHour = parseTrackQuery({ timespan: '1h' }, NOW).window
+
+    expect(beyond24?.to).toBe(next23?.from)
+    expect(next23?.to).toBe(lastHour?.from)
+    expect(lastHour?.to).toBe(NOW)
+  })
+
+  it('prefers from/to over duration and timespan', () => {
+    const { window } = parseTrackQuery({ from: '2026-08-09T11:00:00Z', duration: '5h', timespan: '9h' }, NOW)
+    expect(window).toEqual({ from: NOW - HOUR, to: NOW, inclusiveEnd: true })
+  })
+
+  it('parses resolution as a duration in milliseconds', () => {
+    expect(parseTrackQuery({ resolution: '5s' }, NOW).resolution).toBe(5_000)
+    expect(parseTrackQuery({ resolution: '1m' }, NOW).resolution).toBe(60_000)
+    // Freeboard also sends bare numbers for resolution elsewhere in the API
+    expect(parseTrackQuery({ resolution: '60' }, NOW).resolution).toBe(60_000)
+  })
+
+  it('ignores a zero resolution rather than thinning everything away', () => {
+    expect(parseTrackQuery({ resolution: '0' }, NOW).resolution).toBeUndefined()
+  })
+
+  it('takes the first value when express repeats a parameter', () => {
+    expect(parseTrackQuery({ timespan: ['1h', '9h'] }, NOW).window).toEqual({
+      from: NOW - HOUR,
+      to: NOW,
+      inclusiveEnd: true,
+    })
+  })
+})
+
+describe('thin', () => {
+  const points = (...offsets: number[]): TimedPosition[] =>
+    offsets.map((offset) => ({ position: [offset, offset], timestamp: NOW + offset }))
+
+  it('returns everything when no resolution is set', () => {
+    const p = points(0, 1, 2)
+    expect(thin(p, undefined)).toEqual(p)
+  })
+
+  it('drops points closer together than the resolution', () => {
+    const p = points(0, 100, 200, 1000, 1100, 2000)
+    expect(thin(p, 1000).map((x) => x.timestamp - NOW)).toEqual([0, 1000, 2000])
+  })
+
+  it('always keeps the last point so the track keeps its extent', () => {
+    const p = points(0, 100, 200)
+    const result = thin(p, 1000)
+    expect(result[0]?.timestamp).toBe(NOW)
+    expect(result[result.length - 1]?.timestamp).toBe(NOW + 200)
+  })
+
+  it('leaves one- and two-point tracks alone', () => {
+    expect(thin(points(0), 1000)).toHaveLength(1)
+    expect(thin(points(0, 1), 1000)).toHaveLength(2)
+  })
+})

--- a/src/timeWindow.ts
+++ b/src/timeWindow.ts
@@ -1,0 +1,154 @@
+import { Type } from 'typebox'
+import { Value } from 'typebox/value'
+import type { TimedPosition, TimeWindow } from './types.js'
+
+/**
+ * Time-window and resolution query parameters.
+ *
+ * Two vocabularies are accepted:
+ *
+ * - `from` / `to` / `duration` mirror the Signal K History API and are the
+ *   shape proposed for the track API in SignalK/signalk-server#2504.
+ * - `timespan` / `timespanOffset` are what Freeboard-SK sends today. They are
+ *   compatibility only, not part of any spec, and are expected to be dropped
+ *   once Freeboard moves to the parameters above.
+ *
+ * `resolution` is shared by both and expresses the minimum spacing between
+ * returned points, thinning the track for wide time ranges.
+ */
+const QuerySchema = Type.Object({
+  from: Type.Optional(Type.String()),
+  to: Type.Optional(Type.String()),
+  duration: Type.Optional(Type.String()),
+  timespan: Type.Optional(Type.String()),
+  timespanOffset: Type.Optional(Type.String()),
+  resolution: Type.Optional(Type.String()),
+})
+
+export class TimeWindowError extends Error {}
+
+/** `30`, `30s`, `5m`, `2h`, `7d` — seconds unless suffixed. Returns milliseconds. */
+const DURATION_PATTERN = /^(\d+(?:\.\d+)?)\s*([smhd])?$/
+
+const UNIT_MS: Record<string, number> = {
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+}
+
+export function parseDuration(value: string): number {
+  const match = DURATION_PATTERN.exec(value.trim())
+  const amount = match?.[1]
+  if (!amount) {
+    throw new TimeWindowError(`Invalid duration '${value}', expected a number optionally suffixed with s, m, h or d`)
+  }
+  const unit = match[2] ?? 's'
+  const scale = UNIT_MS[unit]
+  if (scale === undefined) {
+    throw new TimeWindowError(`Invalid duration unit '${unit}'`)
+  }
+  return Number(amount) * scale
+}
+
+function parseInstant(value: string, name: string): number {
+  const ms = Date.parse(value)
+  if (Number.isNaN(ms)) {
+    throw new TimeWindowError(`Invalid ${name} '${value}', expected an ISO-8601 timestamp`)
+  }
+  return ms
+}
+
+/** Express repeats a query key into an array; take the first usable string. */
+function firstString(value: unknown): string | undefined {
+  const scalar: unknown = Array.isArray(value) ? (value as unknown[])[0] : value
+  return typeof scalar === 'string' && scalar.trim() !== '' ? scalar : undefined
+}
+
+export interface TrackQuery {
+  window?: TimeWindow
+  /** Minimum spacing between returned points, in milliseconds. */
+  resolution?: number
+}
+
+/**
+ * Resolve the time-window parameters into an absolute `[from, to)` window.
+ *
+ * Precedence: explicit `from`/`to` win; then `duration`; then the Freeboard
+ * `timespan`/`timespanOffset` pair. Absent all of them, no window is applied
+ * and the whole retained track is returned, as before.
+ */
+export function parseTrackQuery(query: Record<string, unknown>, now: number = Date.now()): TrackQuery {
+  const raw = {
+    from: firstString(query.from),
+    to: firstString(query.to),
+    duration: firstString(query.duration),
+    timespan: firstString(query.timespan),
+    timespanOffset: firstString(query.timespanOffset),
+    resolution: firstString(query.resolution),
+  }
+
+  if (!Value.Check(QuerySchema, raw)) {
+    throw new TimeWindowError('Invalid track query parameters')
+  }
+
+  const result: TrackQuery = {}
+
+  if (raw.resolution !== undefined) {
+    const resolution = parseDuration(raw.resolution)
+    if (resolution > 0) {
+      result.resolution = resolution
+    }
+  }
+
+  // A window ending at `now` includes its final point, so the newest fix is not
+  // dropped. A window ending earlier stays half-open so consecutive bands tile
+  // without repeating the point they share.
+  if (raw.from !== undefined || raw.to !== undefined) {
+    const from = raw.from !== undefined ? parseInstant(raw.from, 'from') : Number.NEGATIVE_INFINITY
+    const to = raw.to !== undefined ? parseInstant(raw.to, 'to') : now
+    if (from >= to) {
+      throw new TimeWindowError(`'from' must be before 'to'`)
+    }
+    return { ...result, window: { from, to, inclusiveEnd: raw.to === undefined } }
+  }
+
+  if (raw.duration !== undefined) {
+    const duration = parseDuration(raw.duration)
+    return { ...result, window: { from: now - duration, to: now, inclusiveEnd: true } }
+  }
+
+  if (raw.timespan !== undefined) {
+    // Freeboard sends timespan with an optional offset back from now, so
+    // `timespan=23h&timespanOffset=1` means "23 hours ending an hour ago".
+    const span = parseDuration(raw.timespan)
+    const offset = raw.timespanOffset !== undefined ? parseDuration(`${raw.timespanOffset}h`) : 0
+    const to = now - offset
+    return { ...result, window: { from: to - span, to, inclusiveEnd: offset === 0 } }
+  }
+
+  return result
+}
+
+/**
+ * Drop points closer together than `resolution` milliseconds, always keeping
+ * the first and last so the track keeps its extent.
+ */
+export function thin(points: TimedPosition[], resolution: number | undefined): TimedPosition[] {
+  if (!resolution || points.length <= 2) {
+    return points
+  }
+  const result: TimedPosition[] = []
+  let lastKept = Number.NEGATIVE_INFINITY
+  for (const point of points) {
+    if (point.timestamp - lastKept >= resolution) {
+      result.push(point)
+      lastKept = point.timestamp
+    }
+  }
+  const last = points[points.length - 1]
+  if (last && result[result.length - 1] !== last) {
+    result.push(last)
+  }
+  return result
+}

--- a/src/tracks.ts
+++ b/src/tracks.ts
@@ -1,7 +1,9 @@
 import { BehaviorSubject, combineLatest, connectable, firstValueFrom, ReplaySubject, Subject } from 'rxjs'
 import type { Connectable, Observable } from 'rxjs'
-import { map, scan, throttleTime } from 'rxjs/operators'
-import type { Context, Debug, LatLngTuple, TrackCollection, TrackParams } from './types.js'
+import { map, scan, startWith, throttleTime } from 'rxjs/operators'
+import { thin } from './timeWindow.js'
+import type { TrackQuery } from './timeWindow.js'
+import type { Context, Debug, LatLngTuple, TimedPosition, TimeWindow, TrackCollection, TrackParams } from './types.js'
 import { createMatcher } from './utils.js'
 
 interface TracksMap {
@@ -31,12 +33,12 @@ export class Tracks {
     this.debug = debug
   }
 
-  newPosition(context: Context, position: LatLngTuple): void {
-    this.getAccumulator(context)?.nextLatLngTuple(position)
+  newPosition(context: Context, position: LatLngTuple, timestamp?: number): void {
+    this.getAccumulator(context)?.nextLatLngTuple(position, timestamp)
   }
 
-  initialTrack(context: Context, track: LatLngTuple[]): void {
-    this.getAccumulator(context)?.setInitialTrack(track)
+  initialTrack(context: Context, track: LatLngTuple[], timestamps?: number[]): void {
+    this.getAccumulator(context)?.setInitialTrack(track, timestamps)
   }
 
   getAccumulator(context: Context, createIfMissing = true): TrackAccumulator | undefined {
@@ -53,35 +55,54 @@ export class Tracks {
     return result
   }
 
-  get(context: Context): Promise<LatLngTuple[]> {
-    const accumulator = this.getAccumulator(context, false)
-    if (accumulator) {
-      // Rejects with EmptyError if the stream completes without emitting; the
-      // route handlers turn that into the same 404 as an unknown context.
-      return firstValueFrom(accumulator.track)
-    } else {
-      return Promise.reject(new Error(`No track accumulator for ${context}`))
-    }
+  get(context: Context, window?: TimeWindow): Promise<LatLngTuple[]> {
+    return this.getTimed(context, window).then((points) => points.map(({ position }) => position))
   }
 
-  getAllTracks(): Promise<VesselTrack[]> {
+  /**
+   * Track points with their timestamps, optionally narrowed to a time window.
+   *
+   * Rejects with EmptyError if the stream completes without emitting; the route
+   * handlers turn that into the same 404 as an unknown context.
+   */
+  getTimed(context: Context, window?: TimeWindow): Promise<TimedPosition[]> {
+    const accumulator = this.getAccumulator(context, false)
+    if (!accumulator) {
+      return Promise.reject(new Error(`No track accumulator for ${context}`))
+    }
+    return firstValueFrom(accumulator.timedTrack).then((points) =>
+      window
+        ? points.filter(
+            ({ timestamp }) =>
+              timestamp >= window.from && (window.inclusiveEnd ? timestamp <= window.to : timestamp < window.to),
+          )
+        : points,
+    )
+  }
+
+  getAllTracks(query?: TrackQuery): Promise<VesselTrack[]> {
     return Promise.all(
       Object.keys(this.tracks).map((context) =>
-        this.get(context).then((track) => ({
+        this.getTimed(context, query?.window).then((points) => ({
           context,
-          track,
+          track: thin(points, query?.resolution).map(({ position }) => position),
         })),
       ),
     )
   }
 
   // Return all / filtered vessels and their tracks
-  async getFilteredTracks(params: TrackParams, selfPosition?: LatLngTuple, debug?: Debug): Promise<TrackCollection> {
+  async getFilteredTracks(
+    params: TrackParams,
+    selfPosition?: LatLngTuple,
+    debug?: Debug,
+    query?: TrackQuery,
+  ): Promise<TrackCollection> {
     this.debug(params)
     this.debug('Self position', selfPosition)
     const matcher = createMatcher(params, selfPosition, debug)
 
-    return this.getAllTracks().then((contextTracks) => {
+    return this.getAllTracks(query).then((contextTracks) => {
       return contextTracks.reduce<TrackCollection>((acc, { context, track }) => {
         if (matcher(track)) {
           acc[context] = track
@@ -113,10 +134,13 @@ interface AccumulatorParams {
 }
 
 export class TrackAccumulator {
-  initialTrack: Subject<LatLngTuple[]> = new BehaviorSubject<LatLngTuple[]>([])
-  input: Subject<LatLngTuple> = new Subject()
+  initialTrack: Subject<TimedPosition[]> = new BehaviorSubject<TimedPosition[]>([])
+  input: Subject<TimedPosition> = new Subject()
   latestLatLngTuple = 0
-  accumulatedTrack: Connectable<LatLngTuple[]>
+  accumulatedTrack: Connectable<TimedPosition[]>
+  /** Timestamped points, used to answer time-window queries. */
+  timedTrack: Observable<TimedPosition[]>
+  /** Positions only — the long-standing public shape. */
   track: Observable<LatLngTuple[]>
 
   constructor({ resolution, pointsToKeep, fetchTrackFor }: AccumulatorParams) {
@@ -126,35 +150,43 @@ export class TrackAccumulator {
     this.accumulatedTrack = connectable(
       this.input.pipe(
         throttleTime(resolution),
-        scan<LatLngTuple, LatLngTuple[]>((acc, position) => {
-          acc.push(position)
+        scan<TimedPosition, TimedPosition[]>((acc, point) => {
+          acc.push(point)
           return acc.slice(Math.max(0, acc.length - pointsToKeep))
         }, []),
+        // combineLatest below only emits once every source has, and `scan` stays
+        // silent until the first live position. Without this an accumulator that
+        // has only been given an initial track — the state after a History API
+        // bootstrap, before any live delta — never yields a readable track.
+        startWith<TimedPosition[]>([]),
       ),
-      { connector: () => new ReplaySubject<LatLngTuple[]>(1), resetOnDisconnect: false },
+      { connector: () => new ReplaySubject<TimedPosition[]>(1), resetOnDisconnect: false },
     )
-    this.track = combineLatest([this.initialTrack, this.accumulatedTrack]).pipe(
+    this.timedTrack = combineLatest([this.initialTrack, this.accumulatedTrack]).pipe(
       map(([initialTrack, accumulatedTrack]) => [...initialTrack, ...accumulatedTrack]),
     )
+    this.track = this.timedTrack.pipe(map((points) => points.map(({ position }) => position)))
     this.accumulatedTrack.connect()
 
     if (fetchTrackFor) {
       void fetchTrack(fetchTrackFor).then((trackGEOJson) => {
         const coordinates = trackGEOJson?.coordinates?.[0]
         if (coordinates) {
-          this.initialTrack.next(coordinates)
+          // The fetched track carries no timestamps; date them at the start of
+          // time so a time-window query treats them as older than anything live.
+          this.initialTrack.next(coordinates.map((position) => ({ position, timestamp: 0 })))
         }
       })
     }
   }
 
-  nextLatLngTuple(position: LatLngTuple): void {
-    this.input.next(position)
-    this.latestLatLngTuple = Date.now()
+  nextLatLngTuple(position: LatLngTuple, timestamp: number = Date.now()): void {
+    this.input.next({ position, timestamp })
+    this.latestLatLngTuple = timestamp
   }
 
-  setInitialTrack(track: LatLngTuple[]): void {
-    this.initialTrack.next(track)
+  setInitialTrack(track: LatLngTuple[], timestamps?: number[]): void {
+    this.initialTrack.next(track.map((position, i) => ({ position, timestamp: timestamps?.[i] ?? 0 })))
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,32 @@ export type Context = string
 export type LatLngTuple = [number, number]
 export type LngLatTuple = [number, number]
 
+/**
+ * A track point with the time it was recorded, in epoch milliseconds.
+ *
+ * Positions are stored as bare `LatLngTuple`s on the wire and in the public
+ * `track` observable; timestamps are kept alongside so time-window queries
+ * (`from`/`to`/`duration`) can slice a track without changing that shape.
+ */
+export interface TimedPosition {
+  position: LatLngTuple
+  timestamp: number
+}
+
+/**
+ * A time window in epoch milliseconds, half-open as `[from, to)`.
+ *
+ * Half-open so the bands a client requests to cover a long trail tile exactly:
+ * `[now-24h, now-1h)` and `[now-1h, now]` share the boundary point without
+ * returning it twice. `inclusiveEnd` closes the final band so the newest fix is
+ * not dropped from a "last hour" query.
+ */
+export interface TimeWindow {
+  from: number
+  to: number
+  inclusiveEnd?: boolean
+}
+
 export interface Position {
   latitude: number
   longitude: number

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       fileName: 'index',
     },
     rollupOptions: {
-      external: [/^node:/, 'rxjs', 'rxjs/operators', 'express'],
+      external: [/^node:/, 'rxjs', 'rxjs/operators', 'express', /^typebox/],
     },
     sourcemap: true,
     minify: false,


### PR DESCRIPTION
Freeboard-SK's server-side vessel trail has been silently broken: it requests a route the plugin never registered, with parameters the plugin never implemented.

## The bug, confirmed on a live server

Against a Signal K server running tracks 2.1.0:

```
GET /signalk/v1/api/self/track?timespan=1h&resolution=60   -> 404 Cannot GET
GET /signalk/v1/api/vessels/self/track                     -> 404 (see #18)
GET /signalk/v1/api/vessels/urn:mrn:...:211161020/track     -> 200, 995 points
  ...with ?timespan=1h                                     -> 200, 995 points
  ...with ?timespan=1h&resolution=60                        -> 200, 995 points
```

So the route Freeboard calls does not exist, and on the route that does, the parameters do nothing — all three of Freeboard's resolution bands would return the same full track. Freeboard catches the failure and sets the trail to `null`, which is why this shows up as a missing feature rather than an error (freeboard-sk#492). Nothing else in the ecosystem implements these parameters; `timespanOffset` appears only in Freeboard's own source.

## What this adds

`/self/track`, plus two vocabularies for the window on both single-vessel routes:

| Parameter | Meaning |
|---|---|
| `from` / `to` / `duration` | Mirrors the History API — the shape proposed in signalk-server#2504 |
| `timespan` / `timespanOffset` | What Freeboard sends today |
| `resolution` | Minimum spacing between returned points |

Both vocabularies ship together deliberately. The spec-shaped names are live from day one, and `timespan`/`timespanOffset` become a thin alias to delete once Freeboard migrates, rather than a fork in the code. **`timespanOffset` is compatibility only and is not part of any spec.**

Durations accept `30`, `5s`, `1m`, `2h`, `7d` — matching what Freeboard actually sends (`5s`, `1m`, `5m`).

### Window boundaries

A window ending at *now* includes its final point, so a "last hour" query does not drop the newest fix. A window ending earlier stays half-open, so the three bands Freeboard requests tile exactly — a test asserts 73 points across three bands with zero duplicates, which is what makes them safe to concatenate client-side.

## A pre-existing bug this uncovered

`combineLatest` emits only once every source has, and the accumulated stream stayed silent until the first live position. So after `bootstrapSelfTrack` restored a track from history, the track was **unreadable until the vessel moved**. Reproduced on `main` independently of this change; fixed with `startWith([])`.

## Notes for review

- Track points now carry a timestamp, taken from the delta rather than arrival time so replayed or delayed data is filed at the time it was recorded. The public `track` observable keeps its `LatLngTuple[]` shape; timestamps live on a parallel `timedTrack`.
- Query parameters are validated with `typebox` (the 1.x line, published unscoped). It is externalised from the bundle so it resolves at runtime like rxjs — the packed tarball stays at 93 kB.
- `src/harness.test-utils.ts` also appears in #36; whichever lands second will need a trivial conflict resolution.

## Verification

`npm run typecheck`, `npm run lint`, `npm run format:check`, `npm test` (51 passing) and `npm run build` all pass.

The packed tarball was installed into a fixture and loaded through a copy of the server's `importOrRequire()`: it loads via `require()` (with typebox resolving at runtime), registers all four routes, returns 3 points for the full track, 1 for `?timespan=1h`, and 400 for `?from=yesterday`.

Still to do before this is truly closed out: confirm the rendered trail in Freeboard against a real server.