### PR TITLE
Make bootstrapFromHistory actually restore a track

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1",
         "rxjs": "^7.8.2",
         "typebox": "^1.3.11"
       },
@@ -725,6 +726,18 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.58.12",
@@ -3555,6 +3568,12 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@js-temporal/polyfill": "^0.5.1",
     "rxjs": "^7.8.2",
     "typebox": "^1.3.11"
   },

--- a/src/bootstrap.test.ts
+++ b/src/bootstrap.test.ts
@@ -139,6 +139,84 @@ describe('bootstrap from the History API', () => {
   })
 })
 
+describe('provider selection', () => {
+  /**
+   * The server's default history provider falls back to whichever plugin
+   * registered first until the configured one is up. An early bootstrap could
+   * therefore be answered by a provider with no positions — verified on a live
+   * server, where `kip` answered with 0 rows while signalk-questdb held 121.
+   */
+  it('asks for the configured provider by name', async () => {
+    const asked: (string | undefined)[] = []
+    const debug: Debug = Object.assign(() => undefined, { enabled: false })
+    vi.useFakeTimers()
+    const plugin = ThePlugin({
+      debug,
+      error: () => undefined,
+      selfContext: SELF,
+      getSelfPath: () => undefined,
+      streambundle: { getBus: () => ({ onValue: () => () => undefined }) },
+      config: { settings: { historyApi: { defaultProvider: 'signalk-questdb' } } },
+      getHistoryApi: (providerId?: string) => {
+        asked.push(providerId)
+        return Promise.resolve({
+          getValues: () =>
+            Promise.resolve({
+              context: SELF,
+              range: { from: '', to: '' },
+              values: [],
+              data: [['2026-08-08T16:34:00.000000Z', { latitude: 1, longitude: 1 }]],
+            }),
+        })
+      },
+    })
+    plugin.start({ resolution: 0, pointsToKeep: 10, maxAge: 600, bootstrapFromHistory: true })
+    stop = () => plugin.stop()
+    await vi.advanceTimersByTimeAsync(6000)
+
+    expect(asked).toEqual(['signalk-questdb'])
+  })
+
+  it('retries when a provider answers with no data instead of giving up', async () => {
+    let call = 0
+    const debug: Debug = Object.assign(() => undefined, { enabled: false })
+    vi.useFakeTimers()
+    const plugin = ThePlugin({
+      debug,
+      error: () => undefined,
+      selfContext: SELF,
+      getSelfPath: () => undefined,
+      streambundle: { getBus: () => ({ onValue: () => () => undefined }) },
+      getHistoryApi: () =>
+        Promise.resolve({
+          getValues: () => {
+            call++
+            // first answer is empty, as a not-yet-ready provider gives
+            return Promise.resolve({
+              context: SELF,
+              range: { from: '', to: '' },
+              values: [],
+              data: call === 1 ? [] : [['2026-08-08T16:34:00.000000Z', { latitude: 5, longitude: 5 }]],
+            })
+          },
+        }),
+    })
+    plugin.start({ resolution: 0, pointsToKeep: 10, maxAge: 600, bootstrapFromHistory: true })
+    stop = () => plugin.stop()
+
+    const app = express()
+    app.use(API, plugin.signalKApiRoutes(express.Router()))
+
+    await vi.advanceTimersByTimeAsync(6000) // first attempt: empty
+    await vi.advanceTimersByTimeAsync(16000) // retry: has data
+    vi.useRealTimers()
+
+    expect(call).toBeGreaterThan(1)
+    const res = await request(app).get(`${API}/self/track`).expect(200)
+    expect(coords(res.body)).toEqual([[5, 5]])
+  })
+})
+
 describe('bootstrap resilience', () => {
   it('does not throw when the server has no History API', async () => {
     const debug: Debug = Object.assign(() => undefined, { enabled: false })

--- a/src/bootstrap.test.ts
+++ b/src/bootstrap.test.ts
@@ -1,0 +1,161 @@
+import request from 'supertest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import ThePlugin from './index.js'
+import type { Debug, LatLngTuple } from './types.js'
+import express from 'express'
+import { Temporal } from '@js-temporal/polyfill'
+
+const API = '/signalk/v1/api'
+const SELF = 'vessels.urn:mrn:imo:mmsi:123456789'
+
+let stop: (() => void) | undefined
+
+afterEach(() => {
+  stop?.()
+  stop = undefined
+  vi.useRealTimers()
+})
+
+/**
+ * Stand the plugin up with a stubbed History API returning `data` rows, and let
+ * the bootstrap run. Providers disagree on how a position is encoded, so the
+ * rows are supplied verbatim.
+ */
+const queries: { from: unknown; to: unknown }[] = []
+
+async function bootstrapWith(data: unknown[]) {
+  queries.length = 0
+  vi.useFakeTimers()
+  const debug: Debug = Object.assign(() => undefined, { enabled: false })
+  const app = {
+    debug,
+    error: () => undefined,
+    selfContext: SELF,
+    getSelfPath: () => undefined,
+    streambundle: { getBus: () => ({ onValue: () => () => undefined }) },
+    getHistoryApi: () =>
+      Promise.resolve({
+        getValues: (q: { from: unknown; to: unknown }) => {
+          queries.push(q)
+          return Promise.resolve({ context: SELF, range: { from: '', to: '' }, values: [], data })
+        },
+      }),
+  }
+  const plugin = ThePlugin(app)
+  plugin.start({ resolution: 0, pointsToKeep: 1000, maxAge: 600, bootstrapFromHistory: true })
+  stop = () => plugin.stop()
+
+  const expressApp = express()
+  expressApp.use(API, plugin.signalKApiRoutes(express.Router()))
+
+  // clear the bootstrap's initial delay and let its promise chain settle
+  await vi.advanceTimersByTimeAsync(6000)
+  vi.useRealTimers()
+  return expressApp
+}
+
+const coords = (body: { coordinates: number[][][] }) => body.coordinates[0] ?? []
+
+describe('bootstrap from the History API', () => {
+  // The shape signalk-questdb actually returns, captured from a live server.
+  // The original filter required a [lon, lat] array and silently dropped every
+  // one of these rows, so the track bootstrapped empty.
+  it('accepts positions encoded as {latitude, longitude}', async () => {
+    const app = await bootstrapWith([
+      ['2026-08-08T16:34:00.000000Z', { latitude: -17.7696467, longitude: 177.1797346 }],
+      ['2026-08-08T16:35:00.000000Z', { latitude: -17.7696991, longitude: 177.1796442 }],
+    ])
+
+    const res = await request(app).get(`${API}/self/track`).expect(200)
+
+    expect(coords(res.body)).toHaveLength(2)
+    // GeoJSON output is [lng, lat]
+    expect(coords(res.body)[0]).toEqual([177.1797346, -17.7696467])
+  })
+
+  it('accepts positions encoded as a [lon, lat] pair', async () => {
+    const app = await bootstrapWith([
+      ['2026-08-08T16:34:00.000000Z', [177.1797346, -17.7696467]],
+      ['2026-08-08T16:35:00.000000Z', [177.1796442, -17.7696991]],
+    ])
+
+    const res = await request(app).get(`${API}/self/track`).expect(200)
+
+    expect(coords(res.body)).toHaveLength(2)
+    expect(coords(res.body)[0]).toEqual([177.1797346, -17.7696467])
+  })
+
+  it('skips malformed rows rather than failing the whole bootstrap', async () => {
+    const app = await bootstrapWith([
+      ['2026-08-08T16:34:00.000000Z', { latitude: -17.7696467, longitude: 177.1797346 }],
+      ['2026-08-08T16:35:00.000000Z', null],
+      ['2026-08-08T16:36:00.000000Z', { latitude: 'nope', longitude: 177 }],
+      ['2026-08-08T16:37:00.000000Z', [177.1796442, -17.7696991]],
+    ])
+
+    const res = await request(app).get(`${API}/self/track`).expect(200)
+
+    expect(coords(res.body)).toHaveLength(2)
+  })
+
+  // Bootstrapped points must carry their recorded time, or a time-window query
+  // treats the restored track as infinitely old and returns nothing.
+  it('dates bootstrapped points so time windows can select them', async () => {
+    const now = Date.now()
+    const at = (msAgo: number) => new Date(now - msAgo).toISOString()
+    const app = await bootstrapWith([
+      [at(3 * 60 * 60 * 1000), { latitude: 1, longitude: 1 }],
+      [at(30 * 60 * 1000), { latitude: 2, longitude: 2 }],
+    ])
+
+    const all = await request(app).get(`${API}/self/track`).expect(200)
+    const lastHour = await request(app).get(`${API}/self/track?timespan=1h`).expect(200)
+
+    expect(coords(all.body)).toHaveLength(2)
+    expect(coords(lastHour.body)).toHaveLength(1)
+    expect(coords(lastHour.body)[0]).toEqual([2, 2])
+  })
+
+  it('leaves the track empty when history returns nothing usable', async () => {
+    const app = await bootstrapWith([['2026-08-08T16:34:00.000000Z', 'not a position']])
+
+    await request(app).get(`${API}/self/track`).expect(404)
+  })
+
+  // The History API hands providers Temporal.Instant values, not strings, and
+  // providers call Instant methods on them — signalk-questdb does
+  // `from.add(duration)`. Passing ISO strings produced a query that silently
+  // returned the wrong range instead of throwing.
+  it('passes the time range as Temporal.Instant, not ISO strings', async () => {
+    await bootstrapWith([['2026-08-08T16:34:00.000000Z', { latitude: 1, longitude: 1 }]])
+
+    expect(queries).toHaveLength(1)
+    const query = queries[0]!
+    expect(typeof query.from).not.toBe('string')
+    expect(query.from).toBeInstanceOf(Temporal.Instant)
+    expect(query.to).toBeInstanceOf(Temporal.Instant)
+    // the shape providers actually exercise
+    expect(typeof (query.from as Temporal.Instant).add).toBe('function')
+  })
+})
+
+describe('bootstrap resilience', () => {
+  it('does not throw when the server has no History API', async () => {
+    const debug: Debug = Object.assign(() => undefined, { enabled: false })
+    const errors: unknown[][] = []
+    const plugin = ThePlugin({
+      debug,
+      error: (...a: unknown[]) => errors.push(a),
+      selfContext: SELF,
+      getSelfPath: () => undefined,
+      streambundle: { getBus: () => ({ onValue: () => () => undefined }) },
+    })
+    plugin.start({ resolution: 0, pointsToKeep: 10, maxAge: 600, bootstrapFromHistory: true })
+    stop = () => plugin.stop()
+
+    const positions: LatLngTuple[] = [[1, 1]]
+    plugin.getTracks()?.initialTrack(SELF, positions, [Date.now()])
+
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,13 @@ interface App {
   }
   getSelfPath: (path: string) => unknown
   selfContext: string
-  getHistoryApi?: () => Promise<HistoryApi>
+  /** Resolves the named provider, or the configured default when omitted. */
+  getHistoryApi?: (providerId?: string) => Promise<HistoryApi>
+  config?: {
+    settings?: {
+      historyApi?: { defaultProvider?: string }
+    }
+  }
 }
 
 interface Plugin {
@@ -193,6 +199,8 @@ async function bootstrapSelfTrack(app: App, tracks: Tracks_, config: TracksPlugi
     return
   }
 
+  const configuredProvider = app.config?.settings?.historyApi?.defaultProvider
+
   const resolution = toNumber(config.resolution) ?? DEFAULT_RESOLUTION
   const pointsToKeep = toNumber(config.pointsToKeep) ?? DEFAULT_POINTS_TO_KEEP
   const timespanMs = resolution * pointsToKeep
@@ -212,7 +220,12 @@ async function bootstrapSelfTrack(app: App, tracks: Tracks_, config: TracksPlugi
     await sleep(delay)
 
     try {
-      const historyApi = await getHistoryApi()
+      // Ask for the configured provider by name. Without this the server hands
+      // back whichever provider registered first until the configured one is
+      // up, and an early bootstrap gets answered by a plugin that has no
+      // positions — indistinguishable from "no history exists". Naming it makes
+      // the not-yet-registered case a rejection, which the retry loop handles.
+      const historyApi = await getHistoryApi(configuredProvider)
       noProviderCount = 0 // provider resolved — reset counter
 
       const to = new Date()
@@ -253,8 +266,21 @@ async function bootstrapSelfTrack(app: App, tracks: Tracks_, config: TracksPlugi
         }
       }
 
-      debug('History API returned no position data for bootstrap')
-      return // API responded successfully but no data — do not retry
+      // An empty response is not proof there is no history. The server's
+      // default history provider falls back to whichever plugin registered
+      // first until the configured one is up, so an early bootstrap can be
+      // answered by the wrong provider — one that legitimately has no
+      // positions. Retrying costs a few seconds and is the difference between
+      // a restored track and an empty one.
+      debug(
+        `History API returned no position data on attempt ${attempt}/${BOOTSTRAP_MAX_ATTEMPTS}; ` +
+          'the configured provider may not have registered yet',
+      )
+      if (attempt === BOOTSTRAP_MAX_ATTEMPTS) {
+        debug('History API returned no position data for bootstrap')
+        return
+      }
+      continue
     } catch (err) {
       if (isNoProviderError(err)) {
         noProviderCount++

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { Temporal } from '@js-temporal/polyfill'
 import type { Request, RequestHandler, Response, Router } from 'express'
 import { Tracks as Tracks_ } from './tracks.js'
 import { parseTrackQuery, thin, TimeWindowError } from './timeWindow.js'
@@ -38,8 +39,8 @@ interface AllTracksResult {
 // Defined locally to avoid a hard dependency on a specific server-api version
 interface HistoryValuesQuery {
   context: string
-  from: string
-  to: string
+  from: Temporal.Instant
+  to: Temporal.Instant
   pathSpecs: { path: string; aggregate: string }[]
   resolution: number
 }
@@ -144,14 +145,39 @@ const isNoProviderError = (err: unknown): boolean => {
   return text.includes('No history') && text.includes('provider')
 }
 
-/** History API rows are [timestamp, [lon, lat]]; keep only well-formed ones. */
-const isHistoryPositionRow = (row: unknown): row is [string, [number, number]] =>
-  Array.isArray(row) &&
-  row.length >= 2 &&
-  Array.isArray(row[1]) &&
-  row[1].length === 2 &&
-  typeof row[1][0] === 'number' &&
-  typeof row[1][1] === 'number'
+/**
+ * A history row is `[timestamp, position]`. Providers disagree on how the
+ * position is encoded: signalk-questdb returns `{latitude, longitude}`, while
+ * a `[lon, lat]` pair is the shape the History API's own docs describe. Accept
+ * both — rejecting either silently bootstraps an empty track.
+ */
+const historyRowPosition = (row: unknown): LatLngTuple | undefined => {
+  if (!Array.isArray(row) || row.length < 2) {
+    return undefined
+  }
+  const value: unknown = row[1]
+  if (Array.isArray(value) && value.length === 2 && typeof value[0] === 'number' && typeof value[1] === 'number') {
+    // [lon, lat] -> [lat, lng]
+    return [value[1], value[0]]
+  }
+  if (value && typeof value === 'object' && 'latitude' in value && 'longitude' in value) {
+    const { latitude, longitude } = value as Partial<Position>
+    if (typeof latitude === 'number' && typeof longitude === 'number') {
+      return [latitude, longitude]
+    }
+  }
+  return undefined
+}
+
+/** Epoch milliseconds for a history row, or 0 when the timestamp is unusable. */
+const historyRowTimestamp = (row: unknown): number => {
+  const raw: unknown = Array.isArray(row) ? row[0] : undefined
+  if (typeof raw !== 'string') {
+    return 0
+  }
+  const parsed = Date.parse(raw)
+  return Number.isNaN(parsed) ? 0 : parsed
+}
 
 async function bootstrapSelfTrack(app: App, tracks: Tracks_, config: TracksPluginConfig): Promise<void> {
   const { debug } = app
@@ -192,24 +218,30 @@ async function bootstrapSelfTrack(app: App, tracks: Tracks_, config: TracksPlugi
       const to = new Date()
       const from = new Date(to.getTime() - timespanMs)
 
+      // The History API hands providers Temporal.Instant values, not strings —
+      // see parseTimeRangeParams in signalk-server. Providers call Instant
+      // methods on them (signalk-questdb does `from.add(duration)`), so passing
+      // ISO strings here yields a query that silently returns the wrong range.
       const response = await historyApi.getValues({
         context: app.selfContext,
-        from: from.toISOString(),
-        to: to.toISOString(),
+        from: Temporal.Instant.from(from.toISOString()),
+        to: Temporal.Instant.from(to.toISOString()),
         pathSpecs: [{ path: 'navigation.position', aggregate: 'first' }],
         resolution: resolutionSecs,
       })
 
       if (response?.data && response.data.length > 0) {
-        // History API returns [timestamp, [lon, lat]]; flip to [lat, lng] for LatLngTuple.
-        const rows = response.data.filter(isHistoryPositionRow)
-        const positions: LatLngTuple[] = rows.map(([, [lon, lat]]): LatLngTuple => [lat, lon])
+        const positions: LatLngTuple[] = []
         // Carry the recorded times through so bootstrapped points answer
         // time-window queries rather than looking infinitely old.
-        const timestamps = rows.map(([time]) => {
-          const parsed = Date.parse(time)
-          return Number.isNaN(parsed) ? 0 : parsed
-        })
+        const timestamps: number[] = []
+        for (const row of response.data) {
+          const position = historyRowPosition(row)
+          if (position) {
+            positions.push(position)
+            timestamps.push(historyRowTimestamp(row))
+          }
+        }
 
         if (positions.length > 0) {
           tracks.initialTrack(app.selfContext, positions, timestamps)


### PR DESCRIPTION
`bootstrapFromHistory` has never worked against `signalk-questdb`. After a restart the plugin claimed to reload the vessel's track from history; in practice it always started empty and rebuilt only from live positions.

Three independent causes, all found by running the plugin against a live Signal K 2.30.0 server. None was reachable from a unit test, because the fixtures encoded the format the code *assumed*.

## 1. Position shape

The row filter required the position to be a `[lon, lat]` array. questdb returns an object:

```
["2026-08-08T16:34:00.000000Z", {"latitude": -17.7696467, "longitude": 177.1797346}]
```

Every row was discarded, silently. Both encodings are now accepted.

## 2. Time range type

The plugin passed `from`/`to` as ISO strings. The History API hands providers `Temporal.Instant` values (see `parseTimeRangeParams` in signalk-server) and providers call Instant methods on them — questdb does `from.add(duration)`. Strings survive questdb's `from && to` branch by accident because it only calls `.toString()`, so this failed quietly instead of throwing.

## 3. The wrong provider answered

The real cause of the empty track, and the subtlest. `defaultProviderId` falls back to *whichever plugin registered first* until the configured provider is up. The bootstrap fires 5s after start, so on a server with more than one history provider it races.

Measured on the live server, same query, same window:

| provider | rows | `values[0].method` |
|---|---|---|
| `signalk-questdb` (configured default) | 121 | `first` |
| `kip` | **0** | **`average`** |

The bootstrap received `0` rows and `method: "average"` — `kip` answering. Since a provider that legitimately has no data returns the same empty response, the plugin treated it as "no history exists" and gave up permanently.

Two changes: ask for the configured provider **by name** (`settings.historyApi.defaultProvider`), which makes not-yet-registered a rejection the retry loop already handles; and stop treating an empty response as final.

## Verification

Live, on the server that exhibited the bug:

```
before:  /self/track -> 1 point     (live accumulation only)
after:   /self/track -> 121 points  (matches questdb for the 2h window)

Freeboard's bands, with real history:
  ?timespan=1h&resolution=5s                    -> 60 points
  ?timespan=23h&resolution=1m&timespanOffset=1  -> 61 points     60 + 61 = 121, no overlap
  ?timespan=48h&resolution=5m&timespanOffset=24 -> 0  (no data that old)

resolution thins as expected:
  none -> 121 | 5m -> 25 | 15m -> 9 | 1h -> 3
```

72 tests pass; typecheck, lint, format and build clean. The new tests use the row shape captured from the live questdb, assert the query carries `Temporal.Instant` rather than strings, and cover both the named-provider request and the retry-on-empty behaviour.