### PR TITLE
Group the generated release notes by category

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,34 @@
+# Categories for the release notes GitHub generates at tag time, so the
+# changelog comes from merged PRs rather than a hand-maintained file that goes
+# stale. See .github/workflows/release_on_tag.yml.
+#
+# A PR lands in the first category it matches, so order matters: dependencies
+# are listed before the catch-all, and the catch-all is last.
+#
+# Categories match on labels, but human PRs in this repo have historically gone
+# unlabelled, so the dependency category also matches the bot by author. Label a
+# PR to place it deliberately; an unlabelled one still appears, under Other.
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: 🚀 Features
+      labels:
+        - feature
+        - enhancement
+    - title: 🐛 Fixes
+      labels:
+        - bug
+        - fix
+    - title: 📖 Documentation
+      labels:
+        - documentation
+    - title: 📦 Dependencies
+      labels:
+        - dependencies
+      authors:
+        - dependabot
+    - title: Other
+      labels:
+        - '*'

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -7,6 +7,8 @@
 # hand-maintained CHANGELOG file — and then publishes that same
 # commit to npm.
 #
+# .github/release.yml groups those titles into sections by PR label.
+#
 # Publishing from the tag is what keeps the npm version and the
 # repository in step. Publishing by hand let them drift, which is
 # https://github.com/SignalK/tracks/issues/17.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,8 @@ Vite transpiles without type checking, so **`npm run build` passing does not mea
 
 - **One logical change per PR.** Refactors and behaviour changes go in separate PRs.
 - **Angular conventional commits:** `<type>(<scope>): <subject>` — `feat | fix | docs | ci | chore | refactor | test | perf`. Imperative, no trailing period.
-- **PR titles become release notes.** Releases are generated from merged PR titles by `.github/workflows/release_on_tag.yml`, so write the title as the line you'd want a user to read in the changelog.
+- **PR titles become release notes.** Releases are generated from merged PR titles by `.github/workflows/release_on_tag.yml`, so write the title as the line you'd want a user to read in the changelog. There is no CHANGELOG file to maintain.
+- **Label the PR so it lands in the right section.** `.github/release.yml` groups the notes: `feature`/`enhancement` → 🚀 Features, `bug`/`fix` → 🐛 Fixes, `documentation` → 📖 Documentation, `dependencies` → 📦 Dependencies. An unlabelled PR still appears, under Other. `skip-changelog` omits it entirely — for changes with nothing to tell a user.
 - **Branch from latest `main`.** Hyphens in branch names, not slashes.
 - **CI must be green.** `.github/workflows/signalk-ci.yml` calls the canonical `SignalK/signalk-server` reusable workflow across Linux x64/arm64, macOS and Windows on Node 22 and 24.
 


### PR DESCRIPTION
`generate_release_notes` emits one flat list, so a breaking rewrite, a docs correction and a dependabot bump all read with equal weight. This adds `.github/release.yml` to group them — still generated from merged PRs at tag time, still no CHANGELOG file to keep in step.

## What the next release will look like

Simulated against the PRs actually merged since the last tag:

```
### 🚀 Features
* Publish to npm from the release tag                        #39
* Cover the track API routes with end-to-end tests           #36
* Modernize to a strict-TypeScript ESM package built with Vite  #34

### 🐛 Fixes
* Make bootstrapFromHistory actually restore a track         #38
* Serve /self/track and honour the time-window query parameters  #37

### 📖 Documentation
* Correct the bbox coordinate order and document the time parameters  #40

### 📦 Dependencies
* chore(deps): bump actions/stale from 10 to 11              #35

### Other
* docs: add AGENTS.md for contributors and AI assistants     #23
```

## Two things worth knowing

**Labels drive this, and human PRs here have never had any.** Every non-dependabot PR in the repo's history is unlabelled, so a label-only config would have put all of the above in "Other" — the exact problem it is meant to solve. So the dependency category also matches `dependabot` by author, the catch-all keeps unlabelled PRs visible rather than dropping them, and the merged PRs listed above have been labelled.

**Three of the referenced labels did not exist** — `feature`, `fix` and `skip-changelog`. Referencing a missing label is not an error; it simply never matches, so the config would have looked right and quietly done nothing. They have been created.

`skip-changelog` omits a PR entirely, for changes with nothing to tell a user.

The convention is documented in AGENTS.md so it survives past this PR.

## Tested

Categorisation was simulated against the repo's real merged PRs and their labels — that is where the output above comes from, rather than from reading the schema. Both YAML files parse; typecheck, lint, format, 72 tests and build all pass.