### PR TITLE
Require a release-notes label on every pull request

### DIFF
--- a/.github/workflows/require_pr_label.yml
+++ b/.github/workflows/require_pr_label.yml
@@ -1,0 +1,42 @@
+# ─────────────────────────────────────────────────────────────
+# Require a release-notes label on every pull request
+#
+# .github/release.yml groups the generated release notes by label, so an
+# unlabelled PR silently lands in "Other". Every PR merged before this
+# workflow existed did exactly that. Fail the check instead, while the PR is
+# still open and labelling it costs nothing.
+#
+# The accepted labels are exactly the ones release.yml categorises, so a PR
+# that passes this check cannot end up uncategorised. Keep the two in step:
+# adding a label here without a category there reintroduces the silent
+# fallthrough this is meant to prevent.
+# ─────────────────────────────────────────────────────────────
+
+name: Pull Request Labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Dependabot applies `dependencies` itself, but not before this first runs
+    # on `opened`, so the check would fail and then pass on the relabel. Skip
+    # it: those PRs are categorised by author in release.yml regardless.
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: 'feature, enhancement, fix, bug, documentation, dependencies, skip-changelog'
+          message: >
+            This PR needs exactly one release-notes label, and has {{ errorString }}.
+            Pick the section it should appear under in the release notes:
+            feature/enhancement, fix/bug, documentation, dependencies —
+            or skip-changelog if it should not appear at all.

--- a/.github/workflows/require_pr_label.yml
+++ b/.github/workflows/require_pr_label.yml
@@ -35,8 +35,12 @@ jobs:
           mode: exactly
           count: 1
           labels: 'feature, enhancement, fix, bug, documentation, dependencies, skip-changelog'
+          # {{ applied }} lists the labels the PR currently has. Note
+          # {{ errorString }} is only the quantifier — "exactly", "at least",
+          # "at most" — so it reads as nonsense outside a phrase like
+          # "requires {{ errorString }} {{ count }} of".
           message: >
-            This PR needs exactly one release-notes label, and has {{ errorString }}.
+            This PR needs exactly one release-notes label, and has: {{ applied }}.
             Pick the section it should appear under in the release notes:
             feature/enhancement, fix/bug, documentation, dependencies —
             or skip-changelog if it should not appear at all.

--- a/.github/workflows/require_pr_label.yml
+++ b/.github/workflows/require_pr_label.yml
@@ -35,12 +35,13 @@ jobs:
           mode: exactly
           count: 1
           labels: 'feature, enhancement, fix, bug, documentation, dependencies, skip-changelog'
-          # {{ applied }} lists the labels the PR currently has. Note
-          # {{ errorString }} is only the quantifier — "exactly", "at least",
-          # "at most" — so it reads as nonsense outside a phrase like
-          # "requires {{ errorString }} {{ count }} of".
+          # Deliberately free of {{ tokens }}. {{ errorString }} is only the
+          # quantifier ("exactly"/"at least"/"at most") and reads as nonsense
+          # alone, and {{ applied }} is empty in the common case — no labels at
+          # all — leaving dangling punctuation. What the reader needs is the
+          # list to choose from, which is fixed.
           message: >
-            This PR needs exactly one release-notes label, and has: {{ applied }}.
-            Pick the section it should appear under in the release notes:
-            feature/enhancement, fix/bug, documentation, dependencies —
-            or skip-changelog if it should not appear at all.
+            This PR needs exactly one release-notes label. Add the one matching
+            the section it should appear under: feature or enhancement, fix or
+            bug, documentation, dependencies — or skip-changelog to keep it out
+            of the release notes entirely.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Vite transpiles without type checking, so **`npm run build` passing does not mea
 - **One logical change per PR.** Refactors and behaviour changes go in separate PRs.
 - **Angular conventional commits:** `<type>(<scope>): <subject>` — `feat | fix | docs | ci | chore | refactor | test | perf`. Imperative, no trailing period.
 - **PR titles become release notes.** Releases are generated from merged PR titles by `.github/workflows/release_on_tag.yml`, so write the title as the line you'd want a user to read in the changelog. There is no CHANGELOG file to maintain.
-- **Label the PR so it lands in the right section.** `.github/release.yml` groups the notes: `feature`/`enhancement` → 🚀 Features, `bug`/`fix` → 🐛 Fixes, `documentation` → 📖 Documentation, `dependencies` → 📦 Dependencies. An unlabelled PR still appears, under Other. `skip-changelog` omits it entirely — for changes with nothing to tell a user.
+- **Every PR needs exactly one release-notes label**, enforced by `.github/workflows/require_pr_label.yml`. `.github/release.yml` groups the notes: `feature`/`enhancement` → 🚀 Features, `bug`/`fix` → 🐛 Fixes, `documentation` → 📖 Documentation, `dependencies` → 📦 Dependencies. `skip-changelog` omits the PR entirely — for changes with nothing to tell a user. The two files list the same labels on purpose: adding one to the gate without a matching category in `release.yml` puts the PR back in the uncategorised "Other" bucket the gate exists to prevent.
 - **Branch from latest `main`.** Hyphens in branch names, not slashes.
 - **CI must be green.** `.github/workflows/signalk-ci.yml` calls the canonical `SignalK/signalk-server` reusable workflow across Linux x64/arm64, macOS and Windows on Node 22 and 24.
 


### PR DESCRIPTION
#41 made the release notes group by label. This makes sure the labels are actually there.

Without it the failure is silent: an unlabelled PR still appears in the notes, just dumped in "Other". That is what **every** PR merged before #41 did — I had to go back and label #34 and #36–#40 by hand so the 3.0.0 notes would read properly. This check moves that discovery to while the PR is open, when labelling costs nothing.

## Accepted labels

```
feature, enhancement, fix, bug, documentation, dependencies, skip-changelog
```

Exactly one is required.

These are deliberately **not** signalk-server's list (`fix, feature, doc, chore, test, ignore, other, dependencies, refactor`). Four of those — `chore`, `test`, `refactor`, `other` — have no category in this repo's `release.yml`, so a PR could pass the gate and still land in "Other", which is the exact failure the gate exists to prevent. And `doc`/`ignore` would duplicate the `documentation`/`skip-changelog` already in use here.

So the gate accepts precisely what `release.yml` categorises. Verified as an invariant rather than by eye:

```
gate accepts     : bug, dependencies, documentation, enhancement, feature, fix, skip-changelog
release.yml knows: bug, dependencies, documentation, enhancement, feature, fix, skip-changelog

accepted but uncategorised: none
categorised but unreachable: none
```

AGENTS.md notes the two files as a pair, since adding a label to one without the other reopens the hole.

## Dependabot is skipped

It applies `dependencies` itself, but not before this first runs on `opened` — the check would fail, then pass on the relabel, producing a red tick on every dependency PR for no reason. `release.yml` categorises those by author regardless.

## Tested

The invariant above was checked by parsing both files and diffing the label sets. `{{ errorString }}` in the failure message is confirmed against the action's documented template variables. YAML parses; typecheck, lint, format, 79 tests and build all pass.

This PR is itself the first to go through the gate.