### PR TITLE
refactor: extract a TrackStore interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -503,4 +503,5 @@ export default function ThePlugin(app: App): Plugin {
 
 export { Tracks, TrackAccumulator } from './tracks.js'
 export type { TracksConfig } from './tracks.js'
+export type { TrackStore } from './store.js'
 export type * from './types.js'

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { Tracks } from './tracks.js'
+import type { TrackStore } from './store.js'
+import type { Context } from './types.js'
+
+const debug = Object.assign(() => {}, { enabled: false })
+const ctx = 'vessels.urn:mrn:signalk:uuid:test' as Context
+
+const newStore = (): TrackStore => new Tracks({ resolution: 0, pointsToKeep: 100 }, debug)
+
+/**
+ * Contract tests for TrackStore, written against the interface rather than the
+ * class. A second implementation should be able to run this same suite — which
+ * is the point of extracting the interface at all.
+ */
+describe('TrackStore contract', () => {
+  it('reads back a recorded position', async () => {
+    const store = newStore()
+    store.newPosition(ctx, [60, 25], 1000)
+    await expect(store.get(ctx)).resolves.toEqual([[60, 25]])
+  })
+
+  it('keeps timestamps alongside positions', async () => {
+    const store = newStore()
+    store.newPosition(ctx, [60, 25], 1000)
+    await expect(store.getTimed(ctx)).resolves.toEqual([{ position: [60, 25], timestamp: 1000 }])
+  })
+
+  it('rejects for an unknown context rather than resolving empty', async () => {
+    // A known-but-stationary vessel resolves with points; an unknown one must be
+    // distinguishable so the route can answer 404.
+    await expect(newStore().get('vessels.nope' as Context)).rejects.toThrow()
+  })
+
+  it('narrows to a half-open time window', async () => {
+    const store = newStore()
+    store.initialTrack(
+      ctx,
+      [
+        [1, 1],
+        [2, 2],
+        [3, 3],
+      ],
+      [1000, 2000, 3000],
+    )
+    // [1000, 3000) excludes the point exactly at `to`.
+    await expect(store.get(ctx, { from: 1000, to: 3000 })).resolves.toEqual([
+      [1, 1],
+      [2, 2],
+    ])
+  })
+
+  it('closes a half-open window when inclusiveEnd is set', async () => {
+    const store = newStore()
+    store.initialTrack(
+      ctx,
+      [
+        [1, 1],
+        [2, 2],
+        [3, 3],
+      ],
+      [1000, 2000, 3000],
+    )
+    await expect(store.get(ctx, { from: 1000, to: 3000, inclusiveEnd: true })).resolves.toEqual([
+      [1, 1],
+      [2, 2],
+      [3, 3],
+    ])
+  })
+
+  it('lists every known context in getAllTracks', async () => {
+    const store = newStore()
+    store.newPosition(ctx, [60, 25], 1000)
+    store.newPosition('vessels.other' as Context, [61, 26], 1000)
+    const all = await store.getAllTracks()
+    expect(all.map(({ context }) => context).sort()).toEqual(['vessels.other', ctx].sort())
+  })
+
+  it('filters on the last position, not any position', async () => {
+    const store = newStore()
+    // Passes through the bbox but ends far outside it.
+    store.initialTrack(
+      ctx,
+      [
+        [60, 25],
+        [10, 10],
+      ],
+      [1000, 2000],
+    )
+    const filtered = await store.getFilteredTracks({
+      bbox: { sw: [59, 24], ne: [61, 26] },
+      radius: null,
+    })
+    expect(filtered[ctx]).toBeUndefined()
+  })
+
+  it('prunes contexts older than maxAge and keeps fresh ones', async () => {
+    const store = newStore()
+    store.newPosition(ctx, [60, 25], Date.now())
+    store.newPosition('vessels.stale' as Context, [1, 1], Date.now() - 10_000)
+    store.prune(5_000)
+    const remaining = await store.getAllTracks()
+    expect(remaining.map(({ context }) => context)).toEqual([ctx])
+  })
+})

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,71 @@
+import type { Context, Debug, LatLngTuple, TimedPosition, TimeWindow, TrackCollection, TrackParams } from './types.js'
+import type { TrackQuery } from './timeWindow.js'
+
+/**
+ * A track store: somewhere positions are accumulated and queried back.
+ *
+ * The in-memory `Tracks` accumulator is one implementation; a persistent store
+ * is another. The interface is deliberately the surface the plugin already
+ * calls in `index.ts` and nothing more, so that adding an implementation cannot
+ * quietly widen what a store is expected to do.
+ *
+ * Note what is *not* here. `getAllTracks` and `getFilteredTracks` are derived
+ * operations — filtering is a predicate over whole tracks, which the in-memory
+ * implementation applies in JS and a database implementation will want to push
+ * into the query. Both stay on the interface for that reason: a store that can
+ * filter in SQL must be allowed to, rather than being forced to materialise
+ * every track so a caller can filter it afterwards.
+ */
+export interface TrackStore {
+  /** Record a position for a context. `timestamp` defaults to now. */
+  newPosition(context: Context, position: LatLngTuple, timestamp?: number): void
+
+  /**
+   * Seed a context's track, replacing whatever it held.
+   *
+   * Used by the History API bootstrap at startup. `timestamps` is positional
+   * against `track`; points without one are dated to the start of time so a
+   * time-window query treats them as older than anything live.
+   */
+  initialTrack(context: Context, track: LatLngTuple[], timestamps?: number[]): void
+
+  /**
+   * Positions for a context, oldest first, optionally narrowed to a window.
+   *
+   * Rejects when the context is unknown; the route handlers turn that into a
+   * 404. Resolving with `[]` would be indistinguishable from a vessel that is
+   * known but has not moved.
+   */
+  get(context: Context, window?: TimeWindow): Promise<LatLngTuple[]>
+
+  /** As `get`, but keeping the timestamp of each point. */
+  getTimed(context: Context, window?: TimeWindow): Promise<TimedPosition[]>
+
+  /** Every known context and its track, thinned to `query.resolution`. */
+  getAllTracks(query?: TrackQuery): Promise<{ context: string; track: LatLngTuple[] }[]>
+
+  /**
+   * Tracks whose *last* position matches a spatial predicate.
+   *
+   * Matching on the last position rather than any position is what makes this
+   * "vessels currently near here" rather than "vessels that ever passed here".
+   */
+  getFilteredTracks(
+    params: TrackParams,
+    selfPosition?: LatLngTuple,
+    debug?: Debug,
+    query?: TrackQuery,
+  ): Promise<TrackCollection>
+
+  /** Drop contexts whose newest position is older than `maxAge` ms. */
+  prune(maxAge: number): void
+
+  /**
+   * Release any resources held by the store.
+   *
+   * A no-op for the in-memory implementation, which is why it is optional; a
+   * store holding file handles must implement it and the plugin calls it from
+   * `stop()`.
+   */
+  close?(): void
+}

--- a/src/tracks.ts
+++ b/src/tracks.ts
@@ -3,6 +3,7 @@ import type { Connectable, Observable } from 'rxjs'
 import { map, scan, startWith, throttleTime } from 'rxjs/operators'
 import { thin } from './timeWindow.js'
 import type { TrackQuery } from './timeWindow.js'
+import type { TrackStore } from './store.js'
 import type { Context, Debug, LatLngTuple, TimedPosition, TimeWindow, TrackCollection, TrackParams } from './types.js'
 import { createMatcher } from './utils.js'
 
@@ -21,7 +22,12 @@ export interface TracksConfig {
   fetchInitialTrack?: boolean
 }
 
-export class Tracks {
+/**
+ * The in-memory store: a bounded sliding window of positions per context,
+ * held in RxJS accumulators and lost on restart. `bootstrapSelfTrack()` in
+ * index.ts is what re-hydrates it from a History provider at startup.
+ */
+export class Tracks implements TrackStore {
   tracks: TracksMap = {}
   debug: Debug
   config: TracksConfig


### PR DESCRIPTION
Names the seam the in-memory accumulator already sits behind, so the sqlite store coming next has an interface to satisfy rather than a class to imitate.

No behaviour change — `Tracks` gains an `implements` clause and nothing else.

## Shape

`TrackStore` is exactly the surface `index.ts` already calls, and nothing more, so adding an implementation cannot quietly widen what a store is expected to do.

Two choices worth flagging:

- **`getAllTracks`/`getFilteredTracks` stay on the interface.** They look like derived helpers that a store shouldn't need, but filtering is a predicate over whole tracks: a database-backed store should be free to push it into the query. Leaving them off would force every implementation through the materialise-then-filter-in-JS path.
- **`close()` is optional.** The in-memory store has nothing to release. Requiring it would mean a no-op stub purely to satisfy the compiler; the plugin calls it from `stop()` when present.

## Contract tests

`src/store.test.ts` is written against the interface rather than the class, so the sqlite implementation can run the identical suite.

## Verification

Beyond the usual gate (typecheck, lint, 87 tests — 79 existing plus 8 new), I checked that both new artefacts actually constrain something:

- **The interface rejects a bad store.** A deliberately wrong implementation returning `Promise<string[]>` from `get()` fails to compile: `Type 'string' is not assignable to type 'LatLngTuple'`.
- **The contract suite catches a real regression.** Mutating `lastPoint()` from `track.at(-1)` to `track.at(0)` — "matches any position" instead of "matches the last" — fails the last-position test and only that test. `utils.ts` is unchanged in this PR.