### PR TITLE
feat(config): choose the track source with one setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,21 @@
 
 Signal K server plugin that accumulates vessel positions into tracks and implements the track API.
 
-Positions are accumulated into a per-vessel sliding window using a configured time resolution, held
-in memory. On startup the plugin can rehydrate the own vessel's track from a history provider (such
-as `signalk-to-influxdb2` or `signalk-questdb`) so tracks are available immediately after a restart
-instead of starting empty. It works with no history provider installed — tracks simply build up from
-live data.
+Positions are accumulated into a per-vessel sliding window using a configured time resolution. The
+**Where tracks come from after a restart** setting chooses what happens to them:
+
+| Setting   | Behaviour                                                                                                                                                  |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `history` | _(default)_ Held in memory, and the own vessel's track is refilled on startup from a history provider such as `signalk-to-influxdb2` or `signalk-questdb`. |
+| `sqlite`  | Recorded to a database file in the plugin's data directory, so every vessel's track survives a restart with no other plugin required.                      |
+| `memory`  | Held in memory only; tracks start empty after a restart.                                                                                                   |
+
+All three work with no other plugin installed — with `history` and no provider present, tracks simply
+build up from live data. `sqlite` also takes a retention setting, in days, for how long to keep
+positions.
+
+This replaces the earlier `bootstrapFromHistory` checkbox. Existing configurations keep working:
+the setting is still read, with `false` mapping to `memory` and anything else to `history`.
 
 The package also exports a client side `TrackAccumulator` class that manages the track for a single
 vessel, exposing the result as `Observable<LatLngTuple[]>`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,10 @@
 
 import { Temporal } from '@js-temporal/polyfill'
 import type { Request, RequestHandler, Response, Router } from 'express'
+import { join } from 'node:path'
 import { Tracks as Tracks_ } from './tracks.js'
+import { SqliteTrackStore } from './sqliteStore.js'
+import type { TrackStore } from './store.js'
 import { parseTrackQuery, thin, TimeWindowError } from './timeWindow.js'
 import type { TrackQuery } from './timeWindow.js'
 import type { Context, Debug, LatLngTuple, LngLatTuple, Position, TrackCollection } from './types.js'
@@ -67,6 +70,8 @@ interface App {
   }
   getSelfPath: (path: string) => unknown
   selfContext: string
+  /** Plugin-private directory for persistent data; absent on older servers. */
+  getDataDirPath?: () => string
   /** Resolves the named provider, or the configured default when omitted. */
   getHistoryApi?: (providerId?: string) => Promise<HistoryApi>
   config?: {
@@ -91,15 +96,48 @@ interface Plugin {
    * position bus, which throttles against the wall clock. The Signal K server
    * does not use this.
    */
-  getTracks: () => Tracks_ | undefined
+  getTracks: () => TrackStore | undefined
 }
+
+/**
+ * Where tracks come from when the server starts.
+ *
+ * - `memory`: start empty, accumulate from the position bus only.
+ * - `history`: refill from a History provider at startup, then accumulate.
+ * - `sqlite`: persist to disk, so a restart resumes from what was recorded.
+ *
+ * One setting rather than a boolean per source: they are alternatives, and as
+ * independent booleans a user could enable two and have the same positions
+ * loaded twice.
+ */
+export type TrackSource = 'memory' | 'history' | 'sqlite'
 
 interface TracksPluginConfig {
   resolution?: number
   pointsToKeep?: number
   maxAge?: number
   maxRadius?: number
+  source?: TrackSource
+  /** @deprecated superseded by `source`; still honoured for existing configs. */
   bootstrapFromHistory?: boolean
+  /** Days of history to keep when `source` is `sqlite`. 0 keeps everything. */
+  retentionDays?: number
+}
+
+/**
+ * Resolve the effective source, honouring the setting this replaced.
+ *
+ * `bootstrapFromHistory` shipped as a boolean defaulting to true, so an
+ * installed plugin has it saved in its config either way. Reading `source`
+ * first and only then falling back keeps those installs working: an explicit
+ * `false` still means "do not touch the History API", and everything else
+ * lands on the old default of `history`.
+ */
+export const resolveSource = (config: TracksPluginConfig): TrackSource => {
+  if (config.source) {
+    return config.source
+  }
+  return config.bootstrapFromHistory === false ? 'memory' : 'history'
 }
 
 const toLngLat = ([lat, lng]: LatLngTuple): LngLatTuple => [lng, lat]
@@ -185,7 +223,7 @@ const historyRowTimestamp = (row: unknown): number => {
   return Number.isNaN(parsed) ? 0 : parsed
 }
 
-async function bootstrapSelfTrack(app: App, tracks: Tracks_, config: TracksPluginConfig): Promise<void> {
+async function bootstrapSelfTrack(app: App, tracks: TrackStore, config: TracksPluginConfig): Promise<void> {
   const { debug } = app
   const getHistoryApi = app.getHistoryApi
 
@@ -312,7 +350,7 @@ async function bootstrapSelfTrack(app: App, tracks: Tracks_, config: TracksPlugi
 
 export default function ThePlugin(app: App): Plugin {
   let onStop: (() => void)[] = []
-  let tracks: Tracks_ | undefined = undefined
+  let tracks: TrackStore | undefined = undefined
   let defaultMaxRadius: number | undefined = undefined
 
   function getVesselPosition(): LatLngTuple | undefined {
@@ -330,13 +368,34 @@ export default function ThePlugin(app: App): Plugin {
     start: function (config: TracksPluginConfig) {
       const { resolution, pointsToKeep, maxAge, maxRadius } = config
       defaultMaxRadius = toNumber(maxRadius)
-      tracks = new Tracks_(
-        {
-          resolution: toNumber(resolution) ?? DEFAULT_RESOLUTION,
-          pointsToKeep: toNumber(pointsToKeep) ?? DEFAULT_POINTS_TO_KEEP,
-        },
-        app.debug,
-      )
+      const source = resolveSource(config)
+
+      // getDataDirPath is what makes the file the server's to manage (backed up
+      // and removed with the plugin). Without it there is nowhere safe to
+      // write, so fall back to memory rather than guessing at a path.
+      const dataDir = source === 'sqlite' ? app.getDataDirPath?.() : undefined
+      if (source === 'sqlite' && !dataDir) {
+        app.error('source is sqlite but this server provides no plugin data directory; using memory instead')
+      }
+
+      // Always a fresh store, as before this setting existed: a restart must
+      // not keep an accumulator built with a resolution the user has since
+      // changed, and for sqlite the previous handle has been closed by stop().
+      tracks = dataDir
+        ? new SqliteTrackStore(
+            {
+              file: join(dataDir, 'tracks.db'),
+              retention: (toNumber(config.retentionDays) ?? 0) * 24 * 60 * 60 * 1000,
+            },
+            app.debug,
+          )
+        : new Tracks_(
+            {
+              resolution: toNumber(resolution) ?? DEFAULT_RESOLUTION,
+              pointsToKeep: toNumber(pointsToKeep) ?? DEFAULT_POINTS_TO_KEEP,
+            },
+            app.debug,
+          )
       onStop.push(
         app.streambundle.getBus('navigation.position').onValue((update: ContextPosition): void => {
           if (!update.value || update.value.latitude == null || update.value.longitude == null) return
@@ -357,8 +416,10 @@ export default function ThePlugin(app: App): Plugin {
         clearInterval(pruneInterval)
       })
 
-      // Bootstrap self track from History API (async, non-blocking)
-      if (config.bootstrapFromHistory !== false) {
+      // Bootstrap self track from History API (async, non-blocking).
+      // Only for `history`: a sqlite store already holds what it recorded, and
+      // refilling it from a provider would duplicate those positions.
+      if (source === 'history') {
         bootstrapSelfTrack(app, tracks, config).catch((err: unknown) => {
           app.error(`Unexpected error in track bootstrap: ${errorDetail(err)}`)
         })
@@ -374,6 +435,18 @@ export default function ThePlugin(app: App): Plugin {
         }
       })
       onStop = []
+      // Release the file handle a sqlite store holds, so a plugin restart does
+      // not leak it and the WAL gets checkpointed.
+      //
+      // The store itself stays in place: stop() leaves the routes mounted and
+      // keeps serving what was already accumulated, which routes.test.ts pins.
+      // Only a store that needs closing is affected, and it is replaced
+      // wholesale on the next start().
+      try {
+        tracks?.close?.()
+      } catch (err) {
+        app.error(err)
+      }
     },
 
     signalKApiRoutes: function (router: Router) {
@@ -489,12 +562,20 @@ export default function ThePlugin(app: App): Plugin {
           description: 'Include only vessels with position within this range. 0= all vessels',
           default: DEFAULT_MAX_RADIUS,
         },
-        bootstrapFromHistory: {
-          type: 'boolean',
-          title: 'Load historical tracks on startup',
+        source: {
+          type: 'string',
+          title: 'Where tracks come from after a restart',
           description:
-            'On startup, load historical position data from the History API (requires a history provider such as signalk-to-influxdb2). Tracks will be available immediately after restart instead of starting empty.',
-          default: true,
+            'In memory only: start empty and accumulate from live positions. History API: refill on startup from a history provider such as signalk-to-influxdb2 or signalk-questdb. SQLite: record positions to a database file so they survive a restart with no other plugin required.',
+          enum: ['memory', 'history', 'sqlite'],
+          enumNames: ['In memory only', 'Load from the History API on startup', 'Record to a SQLite database'],
+          default: 'history',
+        },
+        retentionDays: {
+          type: 'integer',
+          title: 'Days of track history to keep (SQLite only)',
+          description: 'Positions older than this are deleted. 0 keeps everything.',
+          default: 0,
         },
       },
     },

--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSource } from './index.js'
+
+/**
+ * `source` replaces the `bootstrapFromHistory` boolean. Every installed plugin
+ * has that boolean saved in its config, so these pin the migration: an existing
+ * install must keep behaving exactly as it did before the setting changed.
+ */
+describe('resolveSource', () => {
+  it('defaults to history, matching the old default of bootstrapFromHistory: true', () => {
+    expect(resolveSource({})).toBe('history')
+  })
+
+  it('honours an explicit source', () => {
+    expect(resolveSource({ source: 'sqlite' })).toBe('sqlite')
+    expect(resolveSource({ source: 'memory' })).toBe('memory')
+    expect(resolveSource({ source: 'history' })).toBe('history')
+  })
+
+  it('maps a saved bootstrapFromHistory: false to memory', () => {
+    // Someone who turned the bootstrap off did not want the History API
+    // touched; that must survive the upgrade.
+    expect(resolveSource({ bootstrapFromHistory: false })).toBe('memory')
+  })
+
+  it('maps a saved bootstrapFromHistory: true to history', () => {
+    expect(resolveSource({ bootstrapFromHistory: true })).toBe('history')
+  })
+
+  it('prefers source over the setting it replaced', () => {
+    // Both present: the new setting wins, so choosing sqlite in the UI is not
+    // silently overridden by the leftover boolean.
+    expect(resolveSource({ source: 'sqlite', bootstrapFromHistory: true })).toBe('sqlite')
+    expect(resolveSource({ source: 'history', bootstrapFromHistory: false })).toBe('history')
+  })
+})

--- a/src/sqlitePlugin.test.ts
+++ b/src/sqlitePlugin.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import ThePlugin from './index.js'
+import type { ContextPosition } from './index.js'
+import type { Debug, LatLngTuple, Position } from './types.js'
+import { SELF_CONTEXT } from './harness.test-utils.js'
+
+/**
+ * The plugin wired to a sqlite store, exercising what the shared harness
+ * cannot: the data directory, and what survives a stop/start cycle.
+ */
+type Listener = (update: ContextPosition) => void
+
+const debug: Debug = Object.assign(() => undefined, { enabled: false })
+
+const createApp = (dataDir: string | undefined, selfPosition?: LatLngTuple) => {
+  const listeners: Listener[] = []
+  const errors: unknown[][] = []
+  const app = {
+    debug,
+    error: (...args: unknown[]) => errors.push(args),
+    selfContext: SELF_CONTEXT,
+    getSelfPath: (): unknown =>
+      selfPosition
+        ? { value: { latitude: selfPosition[0], longitude: selfPosition[1] } satisfies Position }
+        : undefined,
+    ...(dataDir === undefined ? {} : { getDataDirPath: () => dataDir }),
+    streambundle: {
+      getBus: () => ({
+        onValue: (cb: Listener) => {
+          listeners.push(cb)
+          return () => {
+            const i = listeners.indexOf(cb)
+            if (i >= 0) listeners.splice(i, 1)
+          }
+        },
+      }),
+    },
+  }
+  const emit = (context: string, position: LatLngTuple, timestamp?: number) => {
+    for (const cb of listeners) {
+      cb({
+        context: context as ContextPosition['context'],
+        value: { latitude: position[0], longitude: position[1] },
+        ...(timestamp === undefined ? {} : { timestamp: new Date(timestamp).toISOString() }),
+      })
+    }
+  }
+  return { app, emit, errors }
+}
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'tracks-plugin-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('source: sqlite', () => {
+  it('writes a database file in the plugin data directory', () => {
+    const { app } = createApp(dir)
+    const plugin = ThePlugin(app)
+    plugin.start({ source: 'sqlite', resolution: 0 })
+    plugin.stop()
+
+    expect(existsSync(join(dir, 'tracks.db'))).toBe(true)
+  })
+
+  it('keeps positions across a stop and start', async () => {
+    const first = createApp(dir)
+    const pluginA = ThePlugin(first.app)
+    pluginA.start({ source: 'sqlite', resolution: 0 })
+    first.emit(SELF_CONTEXT, [60.1, 24.9], 1000)
+    pluginA.stop()
+
+    // A fresh plugin instance against the same directory, as a server restart
+    // would produce. This is the whole point of the sqlite source: without it
+    // the track starts empty.
+    const second = createApp(dir)
+    const pluginB = ThePlugin(second.app)
+    pluginB.start({ source: 'sqlite', resolution: 0 })
+    await expect(pluginB.getTracks()?.get(SELF_CONTEXT as ContextPosition['context'])).resolves.toEqual([[60.1, 24.9]])
+    pluginB.stop()
+  })
+
+  it('falls back to memory and reports it when the server has no data directory', async () => {
+    const { app, emit, errors } = createApp(undefined)
+    const plugin = ThePlugin(app)
+    plugin.start({ source: 'sqlite', resolution: 0 })
+    emit(SELF_CONTEXT, [60.1, 24.9], 1000)
+
+    // Still functional, just not persistent — and it says so rather than
+    // failing to start.
+    await expect(plugin.getTracks()?.get(SELF_CONTEXT as ContextPosition['context'])).resolves.toEqual([[60.1, 24.9]])
+    expect(errors.flat().join(' ')).toMatch(/data directory/)
+    plugin.stop()
+  })
+
+  it('does not reuse a closed store after a restart', async () => {
+    const { app, emit } = createApp(dir)
+    const plugin = ThePlugin(app)
+    plugin.start({ source: 'sqlite', resolution: 0 })
+    plugin.stop()
+
+    // stop() closes the handle. Starting again must build a new store rather
+    // than keep the closed one, which would throw on the next write.
+    plugin.start({ source: 'sqlite', resolution: 0 })
+    emit(SELF_CONTEXT, [61, 25], 2000)
+    await expect(plugin.getTracks()?.get(SELF_CONTEXT as ContextPosition['context'])).resolves.toEqual([[61, 25]])
+    plugin.stop()
+  })
+})


### PR DESCRIPTION
Stacked on #44 — review that first; this PR's diff is against it.

Wires the sqlite store into the plugin and replaces `bootstrapFromHistory` with a single setting.

## Why a setting rather than a second checkbox

`bootstrapFromHistory` was a boolean covering one of what are now three alternatives. Adding sqlite alongside it as another boolean would let a user enable both, and load the same positions twice — once from the History API and once from the database. They are alternatives, so they get one setting:

| `source`  | Behaviour |
| --------- | --------- |
| `history` | _(default)_ In memory, refilled on startup from a history provider. The behaviour before this PR. |
| `sqlite`  | Recorded to a database file; every vessel's track survives a restart, no other plugin needed. |
| `memory`  | In memory only. |

## Existing installs

Every installed plugin has the old boolean saved in its config, so this cannot just be renamed. `resolveSource()` reads `source` first and falls back to it: `false` maps to `memory` — someone who turned the bootstrap off did not want the History API touched, and that has to survive the upgrade — and anything else maps to `history`, the old default. Five tests pin those mappings.

## Lifecycle

The database goes in `app.getDataDirPath()`, so the file is the server's to back up and remove along with the plugin. A server that provides no data directory falls back to memory and logs why, rather than guessing at a path or failing to start.

`stop()` closes the store to release the file handle and checkpoint the WAL, but deliberately leaves it in place: `stop()` keeps the routes mounted and serving what was already accumulated, which `routes.test.ts` pins. `start()` always builds a fresh store, as it did before this change.

## Verification

114 tests pass; typecheck, lint and build clean. New coverage: the database file is created, positions survive a stop/start against a fresh plugin instance, the no-data-directory fallback reports itself, and a restart does not reuse a closed store.

Two notes on getting there:

- My first attempt at `stop()` also cleared the store, which broke two existing tests asserting that a stopped plugin keeps serving. Those tests were right and the change was wrong — closing the handle and discarding the store are separate things.
- The restart test initially passed against a deliberately broken version, because the sqlite path assigns unconditionally and the reset I had added was dead code. Rewriting the selection as a single unconditional assignment made the test meaningful; it now fails if that becomes `??=`.