### PR TITLE
fix(sqlite): honour resolution when storing positions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -385,6 +385,7 @@ export default function ThePlugin(app: App): Plugin {
         ? new SqliteTrackStore(
             {
               file: join(dataDir, 'tracks.db'),
+              resolution: toNumber(resolution) ?? DEFAULT_RESOLUTION,
               retention: (toNumber(config.retentionDays) ?? 0) * 24 * 60 * 60 * 1000,
             },
             app.debug,

--- a/src/sqliteStore.test.ts
+++ b/src/sqliteStore.test.ts
@@ -96,6 +96,75 @@ describe('splitAtAntimeridian', () => {
   })
 })
 
+describe('resolution', () => {
+  it('stores every position when resolution is 0', async () => {
+    const store = newStore()
+    for (let i = 0; i < 5; i++) {
+      store.newPosition(ctx, [60 + i / 1000, 24], 1000 + i * 10)
+    }
+    await expect(store.get(ctx)).resolves.toHaveLength(5)
+    store.close()
+  })
+
+  it('drops positions inside a resolution window', async () => {
+    // A vessel emitting at 8 Hz would otherwise write hundreds of thousands of
+    // rows a day at the default 60s resolution.
+    const store = new SqliteTrackStore({ file: ':memory:', resolution: 60_000 }, debug)
+    store.newPosition(ctx, [60.0, 24], 0)
+    store.newPosition(ctx, [60.1, 24], 10_000)
+    store.newPosition(ctx, [60.2, 24], 30_000)
+    store.newPosition(ctx, [60.3, 24], 60_000)
+    store.newPosition(ctx, [60.4, 24], 90_000)
+    store.newPosition(ctx, [60.5, 24], 120_000)
+
+    // Leading edge: the first of each window survives, the rest are dropped.
+    await expect(store.get(ctx)).resolves.toEqual([
+      [60.0, 24],
+      [60.3, 24],
+      [60.5, 24],
+    ])
+    store.close()
+  })
+
+  it('throttles each context independently', async () => {
+    const store = new SqliteTrackStore({ file: ':memory:', resolution: 60_000 }, debug)
+    store.newPosition(ctx, [60, 24], 0)
+    // A different vessel's first position must not be dropped because this one
+    // just recorded.
+    store.newPosition(other, [61, 25], 1000)
+
+    await expect(store.get(ctx)).resolves.toHaveLength(1)
+    await expect(store.get(other)).resolves.toHaveLength(1)
+    store.close()
+  })
+
+  it('does not throttle a bootstrapped track', async () => {
+    // Bootstrap points are back-dated and already at the provider's own
+    // resolution; throttling them against the newest-seen timestamp would drop
+    // almost all of them.
+    const store = new SqliteTrackStore({ file: ':memory:', resolution: 60_000 }, debug)
+    store.initialTrack(
+      ctx,
+      [
+        [60.0, 24],
+        [60.1, 24],
+        [60.2, 24],
+      ],
+      [1000, 2000, 3000],
+    )
+    await expect(store.get(ctx)).resolves.toHaveLength(3)
+    store.close()
+  })
+
+  it('accepts a live position after a bootstrap', async () => {
+    const store = new SqliteTrackStore({ file: ':memory:', resolution: 60_000 }, debug)
+    store.initialTrack(ctx, [[60.0, 24]], [1000])
+    store.newPosition(ctx, [60.1, 24], 2000)
+    await expect(store.get(ctx)).resolves.toHaveLength(2)
+    store.close()
+  })
+})
+
 describe('segments', () => {
   it('breaks a track where recording stopped', () => {
     const store = newStore()

--- a/src/sqliteStore.ts
+++ b/src/sqliteStore.ts
@@ -85,6 +85,15 @@ interface PositionRow {
 export interface SqliteStoreConfig {
   /** Absolute path to the database file, or ':memory:'. */
   file: string
+  /**
+   * Minimum spacing between stored positions, in ms. 0 stores every one.
+   *
+   * The same `resolution` the in-memory accumulator applies with
+   * `throttleTime`, enforced here on write instead. Without it a boat emitting
+   * position at 8 Hz writes ~700k rows a day rather than the ~1.4k a 60s
+   * resolution implies — a difference that lands on an SD card.
+   */
+  resolution?: number
   /** Drop positions older than this many ms. 0 keeps everything. */
   retention?: number
   /** Cells per bounding box covering. */
@@ -113,12 +122,16 @@ export class SqliteTrackStore implements TrackStore {
   private readonly maxCells: number
   private readonly segmentGap: number
   private readonly retention: number
+  private readonly resolution: number
   private readonly debug: Debug
+  /** Timestamp of the last position stored per context, for throttling. */
+  private readonly lastStored = new Map<string, number>()
 
   constructor(config: SqliteStoreConfig, debug: Debug) {
     this.maxCells = config.maxCells ?? DEFAULT_MAX_CELLS
     this.segmentGap = config.segmentGap ?? DEFAULT_SEGMENT_GAP
     this.retention = config.retention ?? 0
+    this.resolution = config.resolution ?? 0
     this.debug = debug
 
     this.db = new DatabaseSync(config.file)
@@ -140,6 +153,23 @@ export class SqliteTrackStore implements TrackStore {
   }
 
   newPosition(context: Context, position: LatLngTuple, timestamp: number = Date.now()): void {
+    // Leading-edge throttle per context, matching the in-memory accumulator's
+    // throttleTime: the first position in a resolution window is stored and the
+    // rest are dropped, not averaged. A vessel emitting at 8 Hz would otherwise
+    // write hundreds of thousands of rows a day at the default 60s resolution.
+    if (this.resolution > 0) {
+      const previous = this.lastStored.get(context)
+      // `<` not `<=`: two positions sharing a timestamp are the same instant,
+      // and a stored point must not block one that is genuinely later.
+      if (previous !== undefined && timestamp - previous < this.resolution) {
+        return
+      }
+      this.lastStored.set(context, timestamp)
+    }
+    this.store(context, position, timestamp)
+  }
+
+  private store(context: Context, position: LatLngTuple, timestamp: number): void {
     this.insert.run(context, timestamp, position[0], position[1], toSigned(cellIdFor(position)))
   }
 
@@ -147,9 +177,13 @@ export class SqliteTrackStore implements TrackStore {
     // Replaces the context's history, matching the in-memory store: the
     // bootstrap is authoritative for the window it covers.
     this.db.prepare('DELETE FROM positions WHERE context = ?').run(context)
+    // Bypasses the throttle: these points are already at whatever resolution
+    // the history provider returned, and they are back-dated, so throttling
+    // against the newest-seen timestamp would drop most of them.
     for (const [i, position] of track.entries()) {
-      this.newPosition(context, position, timestamps?.[i] ?? 0)
+      this.store(context, position, timestamps?.[i] ?? 0)
     }
+    this.lastStored.delete(context)
   }
 
   private rowsFor(context: Context, window?: TimeWindow): PositionRow[] {


### PR DESCRIPTION
The sqlite store wrote every position it was handed. `resolution` was only ever applied by the in-memory accumulator's `throttleTime`, so choosing the sqlite source silently turned it off — the plugin never passed the setting to the store at all.

Found by live testing on a boat, not by the test suite. The unit tests construct the store directly and assert nothing about what the plugin passes it, so a setting that was never wired through was invisible to them.

## Measured

A vessel emitting position at ~8 Hz, with the default 60s resolution:

```
972 rows in 116 seconds  ->  ~722,000 rows/day
a 60s resolution implies ->    ~1,440 rows/day
```

Roughly 500x write amplification, onto what on most installs is an SD card, and the database grows at the same multiple. This is the setting's whole purpose, so a user picking `sqlite` got a far worse outcome than they asked for.

## Fix

Throttles on write, leading-edge and per context, matching what `throttleTime` does for the in-memory store: the first position in each resolution window is stored, the rest dropped rather than averaged. Per context, so one vessel recording does not suppress another's first fix.

`initialTrack` bypasses it. Bootstrap points are back-dated and already at whatever resolution the history provider returned, so throttling them against the newest-seen timestamp would drop nearly all of them.

## Verification

119 tests pass; typecheck, lint, build and the plugin API scan are clean. Five new tests cover: every position stored when resolution is 0, drops inside a window, per-context independence, bootstrap bypass, and a live position accepted straight after a bootstrap.

I checked the main test is not vacuous by removing the throttle — the "drops positions inside a resolution window" test fails and the other fourteen still pass.

Also verified live on the same server the bug was found on, alongside the rest of the sqlite source: the database is created under `getDataDirPath()`, positions survive a restart (1,364 rows; the API served 1,088 points immediately after), and a bbox wrapping the antimeridian returns the same vessels as the equivalent non-wrapping box — the boat sits at 177°E, so that path is exercised for real.