### PR TITLE
feat: split tracks into segments across gaps in recording

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { join } from 'node:path'
 import { Tracks as Tracks_ } from './tracks.js'
 import { SqliteTrackStore } from './sqliteStore.js'
 import type { TrackStore } from './store.js'
-import { parseTrackQuery, thin, TimeWindowError } from './timeWindow.js'
+import { parseTrackQuery, segment, thin, TimeWindowError } from './timeWindow.js'
 import type { TrackQuery } from './timeWindow.js'
 import type { Context, Debug, LatLngTuple, LngLatTuple, Position, TrackCollection } from './types.js'
 import { resolveContext, validateParameters } from './utils.js'
@@ -122,6 +122,8 @@ interface TracksPluginConfig {
   bootstrapFromHistory?: boolean
   /** Days of history to keep when `source` is `sqlite`. 0 keeps everything. */
   retentionDays?: number
+  /** Minutes without a fix that start a new track segment. 0 disables. */
+  segmentGapMinutes?: number
 }
 
 /**
@@ -146,6 +148,11 @@ const DEFAULT_RESOLUTION = 60000
 const DEFAULT_POINTS_TO_KEEP = 60 * 2 // 2 hours with default resolution
 const DEFAULT_MAX_AGE = 60 * 10 // ten minutes
 const DEFAULT_MAX_RADIUS = 50 * 1000 //50 kilometers
+// Off by default. Segmenting changes the shape of every response, and measured
+// against real AIS traffic a 5-minute rule split 61 of 879 gaps that were just
+// a slow-updating target rather than a stop. Opt in, and pick a threshold that
+// suits the fleet being watched.
+const DEFAULT_SEGMENT_GAP_MINUTES = 0
 
 // Bootstrap retry configuration:
 // First attempt after 5s (sufficient for warm restarts where InfluxDB is already running).
@@ -351,6 +358,7 @@ async function bootstrapSelfTrack(app: App, tracks: TrackStore, config: TracksPl
 export default function ThePlugin(app: App): Plugin {
   let onStop: (() => void)[] = []
   let tracks: TrackStore | undefined = undefined
+  let segmentGap = 0
   let defaultMaxRadius: number | undefined = undefined
 
   function getVesselPosition(): LatLngTuple | undefined {
@@ -369,6 +377,8 @@ export default function ThePlugin(app: App): Plugin {
       const { resolution, pointsToKeep, maxAge, maxRadius } = config
       defaultMaxRadius = toNumber(maxRadius)
       const source = resolveSource(config)
+      const segmentGapMinutes = toNumber(config.segmentGapMinutes) ?? DEFAULT_SEGMENT_GAP_MINUTES
+      segmentGap = segmentGapMinutes > 0 ? segmentGapMinutes * 60 * 1000 : 0
 
       // getDataDirPath is what makes the file the server's to manage (backed up
       // and removed with the plugin). Without it there is nowhere safe to
@@ -387,6 +397,7 @@ export default function ThePlugin(app: App): Plugin {
               file: join(dataDir, 'tracks.db'),
               resolution: toNumber(resolution) ?? DEFAULT_RESOLUTION,
               retention: (toNumber(config.retentionDays) ?? 0) * 24 * 60 * 60 * 1000,
+              segmentGap,
             },
             app.debug,
           )
@@ -472,7 +483,9 @@ export default function ThePlugin(app: App): Plugin {
             .then((points) => {
               res.json({
                 type: 'MultiLineString',
-                coordinates: [thin(points, query.resolution).map(({ position }) => toLngLat(position))],
+                coordinates: segment(thin(points, query.resolution), segmentGap).map((points) =>
+                  points.map(({ position }) => toLngLat(position)),
+                ),
               })
             })
             .catch(() => {
@@ -577,6 +590,13 @@ export default function ThePlugin(app: App): Plugin {
           title: 'Days of track history to keep (SQLite only)',
           description: 'Positions older than this are deleted. 0 keeps everything.',
           default: 0,
+        },
+        segmentGapMinutes: {
+          type: 'integer',
+          title: 'Split a track after this many minutes without a fix',
+          description:
+            'A gap longer than this starts a new track segment, so a stop overnight or a spell out of AIS range does not draw a straight line across it. 0 (the default) returns the track as a single line, as before. Note that slow-updating AIS targets can legitimately go many minutes between fixes, so a low value will fragment their tracks.',
+          default: DEFAULT_SEGMENT_GAP_MINUTES,
         },
       },
     },

--- a/src/selfTrack.test.ts
+++ b/src/selfTrack.test.ts
@@ -163,3 +163,45 @@ describe('resolution', () => {
     expect(pointCount(res.body)).toBe(5)
   })
 })
+
+describe('segmentation', () => {
+  it('returns one line by default, however large the gaps', async () => {
+    // Segmenting is opt-in: without segmentGapMinutes the response shape is
+    // exactly what it was before the setting existed.
+    const h = createHarness()
+    const now = Date.now()
+    h.seedTrack(
+      SELF_CONTEXT,
+      [
+        [60, 24],
+        [60.1, 24],
+        [60.2, 24],
+      ],
+      [now - 4 * HOUR, now - 2 * HOUR, now],
+    )
+
+    const res = await request(h.app).get(`${API}/self/track`).expect(200)
+    expect(res.body.coordinates).toHaveLength(1)
+  })
+
+  it('splits the track when a gap exceeds segmentGapMinutes', async () => {
+    const h = createHarness({ config: { segmentGapMinutes: 30 } })
+    const now = Date.now()
+    // Two clusters an hour apart: 30 minutes of silence in between.
+    h.seedTrack(
+      SELF_CONTEXT,
+      [
+        [60, 24],
+        [60.1, 24],
+        [60.2, 24],
+        [60.3, 24],
+      ],
+      [now - 2 * HOUR, now - 2 * HOUR + 60_000, now - HOUR, now - HOUR + 60_000],
+    )
+
+    const res = await request(h.app).get(`${API}/self/track`).expect(200)
+    expect(res.body.type).toBe('MultiLineString')
+    expect(res.body.coordinates).toHaveLength(2)
+    expect(res.body.coordinates.map((s: unknown[]) => s.length)).toEqual([2, 2])
+  })
+})

--- a/src/timeWindow.test.ts
+++ b/src/timeWindow.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { parseDuration, parseTrackQuery, thin, TimeWindowError } from './timeWindow.js'
+import { parseDuration, parseTrackQuery, segment, thin, TimeWindowError } from './timeWindow.js'
 import type { TimedPosition } from './types.js'
+
+const MINUTE = 60 * 1000
 
 const NOW = Date.parse('2026-08-09T12:00:00Z')
 const HOUR = 60 * 60 * 1000
@@ -130,5 +132,43 @@ describe('thin', () => {
   it('leaves one- and two-point tracks alone', () => {
     expect(thin(points(0), 1000)).toHaveLength(1)
     expect(thin(points(0, 1), 1000)).toHaveLength(2)
+  })
+})
+
+describe('segment', () => {
+  const at = (timestamp: number): TimedPosition => ({ position: [60, 24], timestamp })
+
+  it('returns one segment when no gap is configured', () => {
+    expect(segment([at(0), at(10 * MINUTE)], undefined)).toHaveLength(1)
+    expect(segment([at(0), at(10 * MINUTE)], 0)).toHaveLength(1)
+  })
+
+  it('returns no segments for an empty track', () => {
+    // Distinguishable from a track that has points, so a caller can tell
+    // "nothing recorded" from "recorded, but empty after filtering".
+    expect(segment([], 5 * MINUTE)).toEqual([])
+  })
+
+  it('splits where the gap is exceeded', () => {
+    const points = [at(0), at(MINUTE), at(30 * MINUTE), at(31 * MINUTE)]
+    const segments = segment(points, 5 * MINUTE)
+    expect(segments.map((s) => s.length)).toEqual([2, 2])
+  })
+
+  it('does not split on a gap exactly equal to the threshold', () => {
+    // `>` not `>=`: a vessel reporting on a fixed 5-minute interval should not
+    // have every single fix become its own segment.
+    expect(segment([at(0), at(5 * MINUTE)], 5 * MINUTE)).toHaveLength(1)
+  })
+
+  it('keeps a single point as its own segment', () => {
+    expect(segment([at(0)], 5 * MINUTE)).toEqual([[at(0)]])
+  })
+
+  it('composes with thin(): thinning first does not invent a join', () => {
+    // thin() drops intermediate points but never moves them, so a real gap
+    // survives thinning and still segments.
+    const points = [at(0), at(MINUTE), at(2 * MINUTE), at(60 * MINUTE)]
+    expect(segment(thin(points, 90 * 1000), 5 * MINUTE).map((s) => s.length)).toEqual([2, 1])
   })
 })

--- a/src/timeWindow.ts
+++ b/src/timeWindow.ts
@@ -152,3 +152,44 @@ export function thin(points: TimedPosition[], resolution: number | undefined): T
   }
   return result
 }
+
+/**
+ * Split points into segments wherever recording stopped for longer than `gap`.
+ *
+ * A track is not one continuous line: a vessel that stops for the night, or
+ * sails out of AIS range and back, leaves a hole. Joining across it draws a
+ * straight line through places the vessel never went — across a headland, or
+ * over an anchorage it actually sat still in.
+ *
+ * Operates on timestamped points rather than inside a store, so both the
+ * in-memory and sqlite stores segment identically, and so it composes with
+ * `thin()` — thinning first, then segmenting, keeps a thinned-away gap from
+ * being invented as a join.
+ *
+ * `gap` of 0 or undefined returns a single segment, preserving the old shape.
+ * An empty input returns no segments rather than one empty one, so a caller can
+ * distinguish "no track" from "a track with no points".
+ */
+export function segment(points: TimedPosition[], gap: number | undefined): TimedPosition[][] {
+  if (points.length === 0) {
+    return []
+  }
+  if (!gap || gap <= 0) {
+    return [points]
+  }
+  const segments: TimedPosition[][] = []
+  let current: TimedPosition[] = []
+  let previous: number | undefined
+  for (const point of points) {
+    if (previous !== undefined && point.timestamp - previous > gap) {
+      segments.push(current)
+      current = []
+    }
+    current.push(point)
+    previous = point.timestamp
+  }
+  if (current.length > 0) {
+    segments.push(current)
+  }
+  return segments
+}


### PR DESCRIPTION
Groundwork for #1, and a correctness fix in its own right.

The track endpoints have always declared `MultiLineString` — a multi-segment type — while emitting a single-element array. A vessel that stops for the night, or drops out of AIS range for a while, gets a straight line drawn across the gap, through places it never went.

Adds an opt-in `segmentGapMinutes`: a gap longer than this starts a new segment.

## Off by default, and why

I started with a 5-minute default and measured it against real traffic rather than trusting it. Across 879 gaps on a live server with 121 vessels in range:

```
1-5m   : 818
5-15m  :  61   <- slow-updating AIS targets, not stops
```

A 5-minute rule would have fragmented those 61 into separate segments. So the default is 0 (unchanged behaviour) and the setting is opt-in, with the AIS caveat in its description. The right threshold depends on the fleet you're watching, which makes it a choice rather than something to inherit.

The existing test suite made the same point independently: switching it on by default broke 8 tests whose fixtures space points hours apart. Those fixtures are unrealistic, but a default that turns them into one-point-per-segment is a default that will surprise people.

## Shape

`segment()` sits next to `thin()` and operates on timestamped points rather than inside a store, so:

- both stores segment identically — it is not a sqlite-only feature
- it composes with thinning; thinning drops points but never moves them, so a real gap survives and still splits

Splits on `>` rather than `>=`, so a vessel reporting on a fixed interval exactly equal to the threshold stays one segment instead of becoming one segment per fix. There's a test pinning that, and I checked it fails if the comparison is flipped.

The sqlite store's own `segmentGap` now takes the same setting, so its `segments()` and the routes cannot disagree.

## Scope

Only the single-vessel routes segment. `/tracks` goes through `getFilteredTracks`, which discards timestamps before the handler sees them — segmenting there means carrying timestamps through that path, which is a wider change than this and belongs in its own PR.

## Verification

127 tests pass; typecheck, lint, build and the plugin API scan clean. New tests cover: default returns one line regardless of gaps, a route-level split at a configured threshold, the `>` boundary, empty input, single point, and composition with `thin()`.

Verified live on a boat server. With `segmentGapMinutes=10` and a real two-hour hole in the data, `/self/track` returned:

```
segments: 2 | sizes: [3, 30]
```

split exactly across the hole, and a single segment with the setting at 0.

## On #1

This is the part of #1 that applies to every vessel. `navigation.state` is reported by 13 of 121 vessels on that same server, so it works as an *additional* opt-in trigger later, not as the primary mechanism. Details in the issue.