### PR TITLE
feat(api): serve the recording time of each track point

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,30 @@ so thinning never shortens the track._
 
 ---
 
+**Retrieve the time each position was recorded:**
+
+`/signalk/v1/api/self/track?duration=6h&times`
+
+```json
+{
+  "type": "MultiLineString",
+  "coordinates": [
+    [
+      [24.9, 60.1],
+      [25.0, 60.2]
+    ]
+  ],
+  "times": [["2026-08-14T09:00:00.000Z", "2026-08-14T09:01:00.000Z"]]
+}
+```
+
+_`times` adds a `times` array positionally aligned with `coordinates`: `times[i][j]` is when
+`coordinates[i][j]` was recorded, as ISO-8601 UTC. It is opt-in because the response grows by
+roughly a third and clients that only draw the geometry have no use for it. Accepts
+`true`/`1`/`yes` and `false`/`0`/`no`; a valueless `?times` reads as true._
+
+---
+
 **Retrieve tracks for all vessels:**
 
 `/signalk/v1/api/tracks`

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import type { TrackStore } from './store.js'
 import { parseTrackQuery, segment, thin, TimeWindowError } from './timeWindow.js'
 import type { TrackQuery } from './timeWindow.js'
 import type { Context, Debug, LatLngTuple, LngLatTuple, Position, TrackCollection } from './types.js'
-import { resolveContext, validateParameters } from './utils.js'
+import { resolveContext, toIsoTimes, validateParameters } from './utils.js'
 
 export interface ContextPosition {
   context: Context
@@ -481,11 +481,11 @@ export default function ThePlugin(app: App): Plugin {
           tracks
             .getTimed(context, query.window)
             .then((points) => {
+              const segments = segment(thin(points, query.resolution), segmentGap)
               res.json({
                 type: 'MultiLineString',
-                coordinates: segment(thin(points, query.resolution), segmentGap).map((points) =>
-                  points.map(({ position }) => toLngLat(position)),
-                ),
+                coordinates: segments.map((points) => points.map(({ position }) => toLngLat(position))),
+                ...(query.times ? { times: segments.map(toIsoTimes) } : {}),
               })
             })
             .catch(() => {

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -1,4 +1,6 @@
+import request from 'supertest'
 import { describe, expect, it } from 'vitest'
+import { createHarness, SELF_CONTEXT } from './harness.test-utils.js'
 import { createInBounds, validateParameters } from './utils.js'
 import { parseTrackQuery } from './timeWindow.js'
 
@@ -48,5 +50,39 @@ describe('README examples', () => {
     expect(parseTrackQuery({ resolution: '5m' }, now).resolution).toBe(300_000)
     expect(parseTrackQuery({ resolution: '30' }, now).resolution).toBe(30_000)
     expect(parseTrackQuery({ resolution: '1d' }, now).resolution).toBe(86_400_000)
+  })
+})
+
+// The `?times` example above, executed end to end: the documented alignment
+// invariant (times[i][j] describes coordinates[i][j]) is the part a consumer
+// relies on, so it is pinned against the real route rather than the parser.
+describe('README ?times example', () => {
+  it('returns times aligned with coordinates', async () => {
+    const h = createHarness({ selfPosition: [60, 24] })
+    try {
+      // Dated against the real clock: `duration=6h` is relative to now, so
+      // fixed calendar timestamps would fall outside the window.
+      const t0 = Date.now() - 60_000
+      h.seedTrack(
+        SELF_CONTEXT,
+        [
+          [60.1, 24.9],
+          [60.2, 25.0],
+        ],
+        [t0, t0 + 30_000],
+      )
+
+      const res = await request(h.app).get('/signalk/v1/api/self/track?duration=6h&times').expect(200)
+
+      expect(res.body.coordinates).toEqual([
+        [
+          [24.9, 60.1],
+          [25.0, 60.2],
+        ],
+      ])
+      expect(res.body.times).toEqual([[new Date(t0).toISOString(), new Date(t0 + 30_000).toISOString()]])
+    } finally {
+      h.stop()
+    }
   })
 })

--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -136,3 +136,60 @@ describe('Freeboard-SK compatibility', () => {
     await request(h.app).get(`${API}/vessels/${SELF_ID}/track?timespan=1h&resolution=60`).expect(200)
   })
 })
+
+// Per-point recording times, for consumers that draw a track as dots spaced by
+// time rather than as a line — the IMO AIS presentation in
+// SignalK/signalk-server#2504. Opt-in so existing clients see no change.
+describe('per-point timestamps', () => {
+  const T0 = Date.UTC(2026, 7, 14, 9, 0, 0)
+  const MINUTE = 60_000
+
+  const seeded = () => {
+    harness = createHarness({ selfPosition: [60, 24] })
+    harness.seedTrack(
+      SELF_CONTEXT,
+      [
+        [60.1, 24.9],
+        [60.2, 25.0],
+      ],
+      [T0, T0 + MINUTE],
+    )
+    return harness
+  }
+
+  it('omits times unless asked', async () => {
+    const res = await request(seeded().app).get(`${API}/vessels/${SELF_ID}/track`).expect(200)
+
+    expect(res.body.times).toBeUndefined()
+    expect(res.body.coordinates[0]).toHaveLength(2)
+  })
+
+  it('serves ISO-8601 UTC times aligned with the coordinates', async () => {
+    const res = await request(seeded().app).get(`${API}/vessels/${SELF_ID}/track?times=true`).expect(200)
+
+    expect(res.body.times).toEqual([['2026-08-14T09:00:00.000Z', '2026-08-14T09:01:00.000Z']])
+    expect(res.body.times[0]).toHaveLength(res.body.coordinates[0].length)
+  })
+
+  it('treats a valueless ?times as true', async () => {
+    const res = await request(seeded().app).get(`${API}/vessels/${SELF_ID}/track?times`).expect(200)
+
+    expect(res.body.times[0][0]).toBe('2026-08-14T09:00:00.000Z')
+  })
+
+  it('honours times=false', async () => {
+    const res = await request(seeded().app).get(`${API}/vessels/${SELF_ID}/track?times=false`).expect(200)
+
+    expect(res.body.times).toBeUndefined()
+  })
+
+  it('400s on an unparseable times value', async () => {
+    await request(seeded().app).get(`${API}/vessels/${SELF_ID}/track?times=maybe`).expect(400)
+  })
+
+  it('serves times on /self/track too', async () => {
+    const res = await request(seeded().app).get(`${API}/self/track?times`).expect(200)
+
+    expect(res.body.times[0]).toHaveLength(2)
+  })
+})

--- a/src/timeWindow.test.ts
+++ b/src/timeWindow.test.ts
@@ -172,3 +172,34 @@ describe('segment', () => {
     expect(segment(thin(points, 90 * 1000), 5 * MINUTE).map((s) => s.length)).toEqual([2, 1])
   })
 })
+
+describe('parseTrackQuery: times', () => {
+  it('is absent unless the parameter is given', () => {
+    expect(parseTrackQuery({}, NOW).times).toBeUndefined()
+  })
+
+  it('reads a valueless ?times as true', () => {
+    // Express parses `?times` into an empty string; that is how a query string
+    // conventionally spells a flag.
+    expect(parseTrackQuery({ times: '' }, NOW).times).toBe(true)
+  })
+
+  it('accepts the usual truthy and falsy spellings', () => {
+    for (const value of ['true', '1', 'yes', 'TRUE']) {
+      expect(parseTrackQuery({ times: value }, NOW).times).toBe(true)
+    }
+    for (const value of ['false', '0', 'no', 'FALSE']) {
+      expect(parseTrackQuery({ times: value }, NOW).times).toBe(false)
+    }
+  })
+
+  it('rejects a value that is neither', () => {
+    expect(() => parseTrackQuery({ times: 'maybe' }, NOW)).toThrow(TimeWindowError)
+  })
+
+  it('combines with a time window', () => {
+    const query = parseTrackQuery({ duration: '1h', times: 'true' }, NOW)
+    expect(query.times).toBe(true)
+    expect(query.window).toEqual({ from: NOW - HOUR, to: NOW, inclusiveEnd: true })
+  })
+})

--- a/src/timeWindow.ts
+++ b/src/timeWindow.ts
@@ -23,6 +23,7 @@ const QuerySchema = Type.Object({
   timespan: Type.Optional(Type.String()),
   timespanOffset: Type.Optional(Type.String()),
   resolution: Type.Optional(Type.String()),
+  times: Type.Optional(Type.String()),
 })
 
 export class TimeWindowError extends Error {}
@@ -59,6 +60,27 @@ function parseInstant(value: string, name: string): number {
   return ms
 }
 
+const TRUE_FLAGS = ['true', '1', 'yes']
+const FALSE_FLAGS = ['false', '0', 'no']
+
+/**
+ * A boolean query parameter. Present but valueless (`?times`) reads as true,
+ * which is how a query string conventionally spells a flag.
+ */
+function parseFlag(value: string | undefined, name: string): boolean {
+  if (value === undefined) {
+    return true
+  }
+  const flag = value.trim().toLowerCase()
+  if (TRUE_FLAGS.includes(flag)) {
+    return true
+  }
+  if (FALSE_FLAGS.includes(flag)) {
+    return false
+  }
+  throw new TimeWindowError(`Invalid ${name} '${value}', expected true or false`)
+}
+
 /** Express repeats a query key into an array; take the first usable string. */
 function firstString(value: unknown): string | undefined {
   const scalar: unknown = Array.isArray(value) ? (value as unknown[])[0] : value
@@ -69,6 +91,16 @@ export interface TrackQuery {
   window?: TimeWindow
   /** Minimum spacing between returned points, in milliseconds. */
   resolution?: number
+  /**
+   * Serve the recording time of every point alongside the geometry.
+   *
+   * Opt-in rather than always-on: the response grows by roughly a third, and
+   * the clients reading these routes today (Freeboard-SK) draw the geometry
+   * and have no use for the times. Consumers that need per-point time — an
+   * IMO-style AIS display drawing dots equally spaced by time, per
+   * SignalK/signalk-server#2504 — ask for it.
+   */
+  times?: boolean
 }
 
 /**
@@ -86,6 +118,7 @@ export function parseTrackQuery(query: Record<string, unknown>, now: number = Da
     timespan: firstString(query.timespan),
     timespanOffset: firstString(query.timespanOffset),
     resolution: firstString(query.resolution),
+    times: firstString(query.times),
   }
 
   if (!Value.Check(QuerySchema, raw)) {
@@ -93,6 +126,13 @@ export function parseTrackQuery(query: Record<string, unknown>, now: number = Da
   }
 
   const result: TrackQuery = {}
+
+  // `?times` with no value is how a query string spells a flag, so a bare key
+  // counts as true; `times=false` turns it back off for a caller building the
+  // parameter list programmatically.
+  if (Object.prototype.hasOwnProperty.call(query, 'times')) {
+    result.times = parseFlag(raw.times, 'times')
+  }
 
   if (raw.resolution !== undefined) {
     const resolution = parseDuration(raw.resolution)

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createInBounds, resolveContext, validateParameters } from './utils.js'
+import { createInBounds, resolveContext, toIsoTimes, validateParameters } from './utils.js'
 
 const SELF = 'vessels.urn:mrn:imo:mmsi:123456789'
 
@@ -90,5 +90,28 @@ describe('validateParameters', () => {
 
   it('takes the first value when express repeats a query parameter', () => {
     expect(validateParameters({ radius: ['500', '900'] }, undefined).radius).toBe(500)
+  })
+})
+
+describe('toIsoTimes', () => {
+  const at = (timestamp: number) => ({ position: [60, 24] as [number, number], timestamp })
+
+  it('formats epoch milliseconds as ISO-8601 UTC', () => {
+    expect(toIsoTimes([at(Date.UTC(2026, 7, 14, 9, 0, 0))])).toEqual(['2026-08-14T09:00:00.000Z'])
+  })
+
+  it('is positionally aligned with the segment it came from', () => {
+    const segment = [at(0), at(1000), at(2000)]
+    expect(toIsoTimes(segment)).toHaveLength(segment.length)
+  })
+
+  it('renders a non-UTC recording time in UTC', () => {
+    // A track outlives the zone it was recorded in, so the wire format is
+    // always UTC regardless of the server's local time.
+    expect(toIsoTimes([at(Date.parse('2026-08-14T09:00:00+12:00'))])).toEqual(['2026-08-13T21:00:00.000Z'])
+  })
+
+  it('returns nothing for an empty segment', () => {
+    expect(toIsoTimes([])).toEqual([])
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,20 @@
-import type { LatLngTuple, GeoBounds, QueryParameters, TrackParams, Debug } from './types.js'
+import type { LatLngTuple, GeoBounds, QueryParameters, TimedPosition, TrackParams, Debug } from './types.js'
 
 const LAT = 0
 const LNG = 1
+
+/**
+ * The recording times of a segment, as ISO-8601 UTC, positionally aligned with
+ * the segment's coordinates.
+ *
+ * UTC because a track outlives the timezone it was recorded in: a passage that
+ * crosses a zone boundary, or a database restored on a boat that has since
+ * moved, must not shift. ISO-8601 rather than the epoch milliseconds held
+ * internally because that is what the rest of Signal K puts on the wire.
+ */
+export function toIsoTimes(segment: TimedPosition[]): string[] {
+  return segment.map(({ timestamp }) => new Date(timestamp).toISOString())
+}
 
 // create function to check position against GeoBounds
 export function createInBounds(bounds: GeoBounds): (position: LatLngTuple | null) => boolean {


### PR DESCRIPTION
Adds an opt-in `?times` parameter to the single-vessel track routes, returning when each position was recorded.

## Why

A track drawn as a line needs only geometry, but a consumer drawing it as *dots spaced by time* needs to know when each fix happened. That is the IMO AIS presentation @jaffadog raised in SignalK/signalk-server#2504 — it cannot be built from a `MultiLineString` alone.

The times were already in the store, used for time-window slicing. They were simply dropped at the response boundary.

## What

`GET /signalk/v1/api/self/track?duration=6h&times`

```json
{
  "type": "MultiLineString",
  "coordinates": [[[24.9, 60.1], [25.0, 60.2]]],
  "times": [["2026-08-14T09:00:00.000Z", "2026-08-14T09:01:00.000Z"]]
}
```

`times[i][j]` is when `coordinates[i][j]` was recorded, so the arrays stay positionally aligned through segmentation. ISO-8601 **UTC**, because a track outlives the timezone it was recorded in — a passage crossing a zone boundary, or a database restored on a boat that has since moved, must not shift.

Accepts `true`/`1`/`yes` and `false`/`0`/`no`; a valueless `?times` reads as true, which is how a query string conventionally spells a flag.

## Compatibility

Opt-in rather than always-on. The response grows by roughly a third, and Freeboard-SK — which reads these routes today — draws only the geometry. **Without the parameter the response is unchanged.**

## Scope

`/tracks` (all vessels) is deliberately untouched: `getFilteredTracks` returns `TrackCollection`, which has no timestamps, so serving them there means widening the `TrackStore` interface. That is a separate change.

## Tested

- 143 tests pass (127 before, 16 added), `typecheck`, `lint`, `format:check` and `build` all clean.
- New coverage: route behaviour with and without the flag, the valueless and `false` spellings, a 400 on an unparseable value, `/self/track`, the `toIsoTimes` helper including a non-UTC input, and the flag through `parseTrackQuery`.
- The README example is executed as a test, per the existing convention in `readme.test.ts`.