### PR TITLE
feat(api): say which track belongs to the own vessel

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ so thinning never shortens the track._
       [25.0, 60.2]
     ]
   ],
-  "times": [["2026-08-14T09:00:00.000Z", "2026-08-14T09:01:00.000Z"]]
+  "times": [["2026-08-14T09:00:00.000Z", "2026-08-14T09:01:00.000Z"]],
+  "context": "vessels.urn:mrn:imo:mmsi:123456789",
+  "isSelf": true
 }
 ```
 
@@ -83,6 +85,10 @@ _`times` adds a `times` array positionally aligned with `coordinates`: `times[i]
 roughly a third and clients that only draw the geometry have no use for it. Accepts
 `true`/`1`/`yes` and `false`/`0`/`no`; a valueless `?times` reads as true._
 
+_`context` is the fully qualified context the track belongs to, and `isSelf` says whether it is
+the own vessel. Asking for `self` resolves the alias, so the response tells you which vessel
+`self` actually is._
+
 ---
 
 **Retrieve tracks for all vessels:**
@@ -90,6 +96,9 @@ roughly a third and clients that only draw the geometry have no use for it. Acce
 `/signalk/v1/api/tracks`
 
 _If `maxRadius` is specified only vessels with last track position within this distance are returned._
+
+_Each entry carries `isSelf`, so the own vessel can be told from an AIS target without
+string-matching the context against the server's self identity._
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,16 @@ interface AllTracksResult {
   [context: string]: {
     type: 'MultiLineString'
     coordinates: LngLatTuple[][]
+    /**
+     * Whether this is the own vessel's track.
+     *
+     * Stated rather than left to the client: telling own vessel from an AIS
+     * target otherwise means string-matching the context against the server's
+     * self identity, which a client can only do if it has fetched that
+     * separately and knows the `vessels.self` alias resolves to a `urn:mrn:`
+     * context. Getting it wrong draws someone else's track as your own.
+     */
+    isSelf: boolean
   }
 }
 
@@ -486,6 +496,8 @@ export default function ThePlugin(app: App): Plugin {
                 type: 'MultiLineString',
                 coordinates: segments.map((points) => points.map(({ position }) => toLngLat(position))),
                 ...(query.times ? { times: segments.map(toIsoTimes) } : {}),
+                context,
+                isSelf: context === app.selfContext,
               })
             })
             .catch(() => {
@@ -527,6 +539,7 @@ export default function ThePlugin(app: App): Plugin {
               acc[context] = {
                 type: 'MultiLineString',
                 coordinates: [track.map(toLngLat)],
+                isSelf: context === app.selfContext,
               }
               return acc
             }, {})

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -81,6 +81,8 @@ describe('README ?times example', () => {
         ],
       ])
       expect(res.body.times).toEqual([[new Date(t0).toISOString(), new Date(t0 + 30_000).toISOString()]])
+      expect(res.body.context).toBe(SELF_CONTEXT)
+      expect(res.body.isSelf).toBe(true)
     } finally {
       h.stop()
     }

--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -193,3 +193,55 @@ describe('per-point timestamps', () => {
     expect(res.body.times[0]).toHaveLength(2)
   })
 })
+
+// Own vessel vs AIS target, stated by the server. A client otherwise has to
+// string-match the context against the self identity it fetched separately,
+// and drawing another vessel's track as your own is the failure mode.
+describe('isSelf', () => {
+  it('marks the own vessel on a single-vessel track', async () => {
+    const h = withTracks([SELF_CONTEXT, [60.1, 24.9]])
+
+    const res = await request(h.app).get(`${API}/vessels/${SELF_ID}/track`).expect(200)
+
+    expect(res.body.isSelf).toBe(true)
+    expect(res.body.context).toBe(SELF_CONTEXT)
+  })
+
+  it('marks an AIS target as not self', async () => {
+    const h = withTracks([OTHER_CONTEXT, [60.2, 24.8]])
+    const otherId = OTHER_CONTEXT.replace('vessels.', '')
+
+    const res = await request(h.app).get(`${API}/vessels/${otherId}/track`).expect(200)
+
+    expect(res.body.isSelf).toBe(false)
+    expect(res.body.context).toBe(OTHER_CONTEXT)
+  })
+
+  it('reports the resolved context when asked for the self alias', async () => {
+    // The alias resolves to the fully qualified urn:mrn: context, so a client
+    // that asked for `self` learns which vessel that actually is.
+    const h = withTracks([SELF_CONTEXT, [60.1, 24.9]])
+
+    const res = await request(h.app).get(`${API}/vessels/self/track`).expect(200)
+
+    expect(res.body.context).toBe(SELF_CONTEXT)
+    expect(res.body.isSelf).toBe(true)
+  })
+
+  it('marks /self/track as self', async () => {
+    const h = withTracks([SELF_CONTEXT, [60.1, 24.9]])
+
+    const res = await request(h.app).get(`${API}/self/track`).expect(200)
+
+    expect(res.body.isSelf).toBe(true)
+  })
+
+  it('distinguishes self from others in the all-tracks listing', async () => {
+    const h = withTracks([SELF_CONTEXT, [60.1, 24.9]], [OTHER_CONTEXT, [60.2, 24.8]])
+
+    const res = await request(h.app).get(`${API}/tracks`).expect(200)
+
+    expect(res.body[SELF_CONTEXT].isSelf).toBe(true)
+    expect(res.body[OTHER_CONTEXT].isSelf).toBe(false)
+  })
+})


### PR DESCRIPTION
Every track now says whether it is the own vessel's.

## Why

`GET /tracks` returns an object keyed by context. To tell its own vessel from an AIS target, a client has to string-match those keys against the server's self identity — which it can only do if it has fetched that separately, and knows that the `vessels.self` alias resolves to a fully qualified `urn:mrn:` context. Getting it wrong draws another vessel's track as your own.

This came out of the track API discussion in SignalK/signalk-server#2504, where distinguishing own-vessel from AIS tracks is a stated requirement — own vessel is the track you keep, AIS targets are the ones bounded by retention.

## What

`isSelf` on every track, in both shapes:

```json
{
  "vessels.urn:mrn:imo:mmsi:123456789": {
    "type": "MultiLineString",
    "coordinates": [ ... ],
    "isSelf": true
  },
  "vessels.urn:mrn:imo:mmsi:987654321": {
    "type": "MultiLineString",
    "coordinates": [ ... ],
    "isSelf": false
  }
}
```

The single-vessel routes additionally return `context`, so a client that asked for `self` learns which vessel that actually is:

```json
{
  "type": "MultiLineString",
  "coordinates": [ ... ],
  "context": "vessels.urn:mrn:imo:mmsi:123456789",
  "isSelf": true
}
```

## Compatibility

Purely additive — every existing field is unchanged, so current clients see no difference.

## Tested

- 148 tests pass (143 before, 5 added), `typecheck`, `lint`, `format:check` and `build` all clean.
- New coverage: self and AIS on the single-vessel route, the `self` alias resolving to the qualified context, `/self/track`, and self-vs-other in the all-tracks listing.
- The README example is executed as a test, per the existing convention.