### PR TITLE
feat: warn when positions arrive from several sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ the setting is still read, with `false` mapping to `memory` and anything else to
 The package also exports a client side `TrackAccumulator` class that manages the track for a single
 vessel, exposing the result as `Observable<LatLngTuple[]>`.
 
+## Position sources
+
+`navigation.position` often arrives from several sources at once — an internal GPS, an AIS
+transponder, a plotter echoing its own fix. Signal K decides which one wins through **source
+priority**, but the stream this plugin listens on carries them all.
+
+Recording every source interleaves fixes from receivers metres apart, so the track zigzags
+between them instead of following the boat. If that is happening, the plugin says so in its
+status on the server dashboard, naming the sources it has seen. The fix is to set a source
+priority for `navigation.position` in the server settings.
+
 # Usage:
 
 **Retrieve track for an individual vessel:**

--- a/src/harness.test-utils.ts
+++ b/src/harness.test-utils.ts
@@ -28,7 +28,9 @@ export interface TestHarness {
    * synchronous burst yields a single point regardless of the timestamps given.
    * Use `seedTrack` to install a back-dated track instead.
    */
-  emit: (context: string, position: LatLngTuple, timestamp?: number) => void
+  emit: (context: string, position: LatLngTuple, timestamp?: number, source?: string) => void
+  /** Status messages the plugin has pushed to the server dashboard. */
+  statuses: string[]
   /**
    * Install a track with explicit timestamps, bypassing the throttled bus. This
    * is the entry point the History API bootstrap uses.
@@ -50,6 +52,7 @@ export interface HarnessOptions {
 export function createHarness(options: HarnessOptions = {}): TestHarness {
   const listeners: PositionListener[] = []
   const errors: unknown[][] = []
+  const statuses: string[] = []
   let selfPosition: LatLngTuple | undefined = options.selfPosition
   const selfContext = options.selfContext ?? SELF_CONTEXT
 
@@ -58,6 +61,7 @@ export function createHarness(options: HarnessOptions = {}): TestHarness {
   const app = {
     debug,
     error: (...args: unknown[]) => errors.push(args),
+    setPluginStatus: (msg: string) => statuses.push(msg),
     selfContext,
     getSelfPath: (): unknown =>
       selfPosition
@@ -91,12 +95,13 @@ export function createHarness(options: HarnessOptions = {}): TestHarness {
 
   return {
     app: expressApp,
-    emit: (context, position, timestamp) => {
+    emit: (context, position, timestamp, source) => {
       for (const cb of listeners) {
         cb({
           context,
           value: { latitude: position[0], longitude: position[1] },
           ...(timestamp === undefined ? {} : { timestamp: new Date(timestamp).toISOString() }),
+          ...(source === undefined ? {} : { $source: source }),
         })
       }
     },
@@ -108,5 +113,6 @@ export function createHarness(options: HarnessOptions = {}): TestHarness {
     },
     stop: () => plugin.stop(),
     errors,
+    statuses,
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { join } from 'node:path'
 import { Tracks as Tracks_ } from './tracks.js'
 import { SqliteTrackStore } from './sqliteStore.js'
 import type { TrackStore } from './store.js'
+import { SourceWatch } from './sourceWatch.js'
 import { parseTrackQuery, segment, thin, TimeWindowError } from './timeWindow.js'
 import type { TrackQuery } from './timeWindow.js'
 import type { Context, Debug, LatLngTuple, LngLatTuple, Position, TrackCollection } from './types.js'
@@ -29,6 +30,12 @@ export interface ContextPosition {
   value: Position
   /** ISO-8601 time the value was recorded, as carried by the Signal K delta. */
   timestamp?: string
+  /**
+   * Which source produced the value. The bus carries every source's values,
+   * not just the one source priority selects, so this is how a multi-receiver
+   * setup is detected.
+   */
+  $source?: string
 }
 
 interface AllTracksResult {
@@ -80,6 +87,8 @@ interface App {
   }
   getSelfPath: (path: string) => unknown
   selfContext: string
+  /** Shown against the plugin in the server's dashboard. Absent on older servers. */
+  setPluginStatus?: (msg: string) => void
   /** Plugin-private directory for persistent data; absent on older servers. */
   getDataDirPath?: () => string
   /** Resolves the named provider, or the configured default when omitted. */
@@ -168,6 +177,11 @@ const DEFAULT_SEGMENT_GAP_MINUTES = 0
 // First attempt after 5s (sufficient for warm restarts where InfluxDB is already running).
 // Subsequent attempts every 15s, up to 18 total (~260s window), covering cold boot scenarios
 // where InfluxDB may take 2+ minutes to accept connections after systemd reports it active.
+// Long enough that a boat with one GPS never pays for the check in practice,
+// short enough that the warning appears while the user is still looking at the
+// plugin page after enabling it.
+const SOURCE_STATUS_INTERVAL_MS = 30000
+
 const BOOTSTRAP_INITIAL_DELAY = 5000
 const BOOTSTRAP_RETRY_DELAY = 15000
 const BOOTSTRAP_MAX_ATTEMPTS = 18
@@ -370,6 +384,7 @@ export default function ThePlugin(app: App): Plugin {
   let tracks: TrackStore | undefined = undefined
   let segmentGap = 0
   let defaultMaxRadius: number | undefined = undefined
+  const sourceWatch = new SourceWatch()
 
   function getVesselPosition(): LatLngTuple | undefined {
     const p = app.getSelfPath('navigation.position')
@@ -421,6 +436,7 @@ export default function ThePlugin(app: App): Plugin {
       onStop.push(
         app.streambundle.getBus('navigation.position').onValue((update: ContextPosition): void => {
           if (!update.value || update.value.latitude == null || update.value.longitude == null) return
+          sourceWatch.add(update.context, update.$source)
           // Prefer the delta's own timestamp so a replayed or delayed update is
           // filed at the time it was recorded, not the time it arrived.
           const recorded = update.timestamp === undefined ? undefined : Date.parse(update.timestamp)
@@ -436,6 +452,20 @@ export default function ThePlugin(app: App): Plugin {
       const pruneInterval = setInterval(() => tracks?.prune(theMaxAge * 1000), (theMaxAge * 1000) / 2)
       onStop.push(() => {
         clearInterval(pruneInterval)
+      })
+
+      // Report on a timer rather than per delta: at 10Hz across several
+      // vessels that would rewrite the status thousands of times a minute, and
+      // the first fix from a second source is not yet evidence of a problem —
+      // a source that appears once and stops is not worth a warning.
+      const statusInterval = setInterval(() => {
+        const warning = sourceWatch.warning(app.selfContext)
+        if (warning) {
+          app.setPluginStatus?.(warning)
+        }
+      }, SOURCE_STATUS_INTERVAL_MS)
+      onStop.push(() => {
+        clearInterval(statusInterval)
       })
 
       // Bootstrap self track from History API (async, non-blocking).
@@ -457,6 +487,10 @@ export default function ThePlugin(app: App): Plugin {
         }
       })
       onStop = []
+      // Forget which sources were seen: the point of a restart is often to
+      // apply a source priority change, and carrying the old observations over
+      // would keep warning about a setup that has just been fixed.
+      sourceWatch.clear()
       // Release the file handle a sqlite store holds, so a plugin restart does
       // not leak it and the WAL gets checkpointed.
       //

--- a/src/sourceWatch.test.ts
+++ b/src/sourceWatch.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createHarness } from './harness.test-utils.js'
+import { SourceWatch } from './sourceWatch.js'
+import type { Context } from './types.js'
+
+const SELF = 'vessels.urn:mrn:imo:mmsi:123456789' as Context
+const OTHER = 'vessels.urn:mrn:imo:mmsi:987654321' as Context
+
+describe('SourceWatch', () => {
+  it('says nothing when every context has a single source', () => {
+    const w = new SourceWatch()
+    w.add(SELF, 'gps.0')
+    w.add(SELF, 'gps.0')
+    w.add(OTHER, 'ais.0')
+
+    expect(w.conflicted()).toEqual([])
+    expect(w.warning(SELF)).toBeUndefined()
+  })
+
+  it('names the sources when the own vessel has more than one', () => {
+    const w = new SourceWatch()
+    w.add(SELF, 'gps.0')
+    w.add(SELF, 'n2k.1')
+
+    const warning = w.warning(SELF)
+    expect(warning).toContain('gps.0')
+    expect(warning).toContain('n2k.1')
+    expect(warning).toContain('source priority')
+  })
+
+  it('counts other vessels rather than naming them', () => {
+    // AIS targets legitimately arrive via several receivers; that is not a
+    // misconfiguration the user needs to fix, so it is not worth naming each.
+    const w = new SourceWatch()
+    w.add(OTHER, 'ais.0')
+    w.add(OTHER, 'ais.1')
+
+    const warning = w.warning(SELF)
+    expect(warning).toContain('1 vessel')
+    expect(warning).not.toContain(OTHER)
+  })
+
+  it('mentions both the own vessel and the count of others', () => {
+    const w = new SourceWatch()
+    w.add(SELF, 'gps.0')
+    w.add(SELF, 'n2k.1')
+    w.add(OTHER, 'ais.0')
+    w.add(OTHER, 'ais.1')
+
+    const warning = w.warning(SELF)
+    expect(warning).toContain('own vessel')
+    expect(warning).toContain('1 other vessel')
+  })
+
+  it('pluralises the count of other vessels', () => {
+    const w = new SourceWatch()
+    for (const [i, mmsi] of ['111', '222'].entries()) {
+      const context = `vessels.urn:mrn:imo:mmsi:${mmsi}` as Context
+      w.add(context, `ais.${i}`)
+      w.add(context, `n2k.${i}`)
+    }
+
+    expect(w.warning(SELF)).toContain('2 vessels')
+  })
+
+  it('ignores a delta with no source', () => {
+    // A source-less delta says nothing about whether priority is configured,
+    // so counting it would warn about a setup that is actually fine.
+    const w = new SourceWatch()
+    w.add(SELF, 'gps.0')
+    w.add(SELF, undefined)
+
+    expect(w.warning(SELF)).toBeUndefined()
+    expect(w.sourcesFor(SELF)).toEqual(['gps.0'])
+  })
+
+  it('reports sources in the order they first appeared', () => {
+    const w = new SourceWatch()
+    w.add(SELF, 'n2k.1')
+    w.add(SELF, 'gps.0')
+    w.add(SELF, 'n2k.1')
+
+    expect(w.sourcesFor(SELF)).toEqual(['n2k.1', 'gps.0'])
+  })
+
+  it('warns without a self context, treating everything as another vessel', () => {
+    const w = new SourceWatch()
+    w.add(SELF, 'gps.0')
+    w.add(SELF, 'n2k.1')
+
+    expect(w.warning(undefined)).toContain('1 vessel')
+  })
+
+  it('forgets what it saw when cleared', () => {
+    const w = new SourceWatch()
+    w.add(SELF, 'gps.0')
+    w.add(SELF, 'n2k.1')
+    w.clear()
+
+    expect(w.warning(SELF)).toBeUndefined()
+  })
+})
+
+// The watcher wired into the plugin: positions arrive on the bus and the
+// warning reaches the server dashboard.
+describe('source warning through the plugin', () => {
+  it('warns on the dashboard when the own vessel has two position sources', () => {
+    vi.useFakeTimers()
+    const h = createHarness({ selfPosition: [60, 24] })
+    try {
+      h.emit(SELF, [60.1, 24.9], undefined, 'gps.0')
+      h.emit(SELF, [60.1, 24.91], undefined, 'n2k.1')
+
+      expect(h.statuses).toEqual([])
+      vi.advanceTimersByTime(30_000)
+
+      expect(h.statuses).toHaveLength(1)
+      expect(h.statuses[0]).toContain('gps.0')
+      expect(h.statuses[0]).toContain('n2k.1')
+    } finally {
+      h.stop()
+      vi.useRealTimers()
+    }
+  })
+
+  it('stays quiet with a single source', () => {
+    vi.useFakeTimers()
+    const h = createHarness({ selfPosition: [60, 24] })
+    try {
+      h.emit(SELF, [60.1, 24.9], undefined, 'gps.0')
+      h.emit(SELF, [60.1, 24.91], undefined, 'gps.0')
+      vi.advanceTimersByTime(120_000)
+
+      expect(h.statuses).toEqual([])
+    } finally {
+      h.stop()
+      vi.useRealTimers()
+    }
+  })
+
+  it('stops reporting once the plugin is stopped', () => {
+    vi.useFakeTimers()
+    const h = createHarness({ selfPosition: [60, 24] })
+    try {
+      h.emit(SELF, [60.1, 24.9], undefined, 'gps.0')
+      h.emit(SELF, [60.1, 24.91], undefined, 'n2k.1')
+      h.stop()
+      vi.advanceTimersByTime(120_000)
+
+      expect(h.statuses).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/sourceWatch.ts
+++ b/src/sourceWatch.ts
@@ -1,0 +1,79 @@
+import type { Context } from './types.js'
+
+/**
+ * Watches which `$source` each context's positions arrive from.
+ *
+ * `navigation.position` is a rapid update — a GPS may report at 10Hz — and a
+ * typical boat has several receivers: an internal GPS, an AIS transponder, a
+ * chart plotter echoing its own fix. Signal K resolves which one *wins* per
+ * path through source priority, but the streambundle bus this plugin listens
+ * on carries every source's values, not just the winner.
+ *
+ * Recording all of them interleaves fixes from receivers metres apart, so the
+ * track zigzags between them rather than following the boat. The fix is to
+ * configure source priority for `navigation.position`; this watcher exists to
+ * say so, because the symptom (a track that looks noisy) does not obviously
+ * point at the cause.
+ *
+ * Detection is empirical rather than reading the server's priority config:
+ * what matters is what actually arrives, and a priority rule that exists but
+ * does not match still produces multiple sources here.
+ */
+export class SourceWatch {
+  private readonly seen = new Map<Context, Set<string>>()
+
+  /** Record that `context` produced a position from `$source`. */
+  add(context: Context, source: string | undefined): void {
+    if (!source) {
+      return
+    }
+    let sources = this.seen.get(context)
+    if (!sources) {
+      sources = new Set()
+      this.seen.set(context, sources)
+    }
+    sources.add(source)
+  }
+
+  /** Sources seen for a context, in the order they first appeared. */
+  sourcesFor(context: Context): string[] {
+    return [...(this.seen.get(context) ?? [])]
+  }
+
+  /** Contexts receiving positions from more than one source. */
+  conflicted(): Context[] {
+    return [...this.seen.entries()].filter(([, sources]) => sources.size > 1).map(([context]) => context)
+  }
+
+  /**
+   * A status line naming the problem, or undefined when nothing is wrong.
+   *
+   * `selfContext` is called out by name because the own vessel's track is the
+   * one a user looks at, and it is the one whose priority they can fix. Other
+   * vessels are usually AIS, where multiple receivers are expected and less
+   * worth nagging about — they are counted, not named.
+   */
+  warning(selfContext?: Context): string | undefined {
+    const conflicted = this.conflicted()
+    if (conflicted.length === 0) {
+      return undefined
+    }
+    const selfConflicted = selfContext !== undefined && conflicted.includes(selfContext)
+    const others = conflicted.length - (selfConflicted ? 1 : 0)
+
+    if (selfConflicted) {
+      const sources = this.sourcesFor(selfContext).join(', ')
+      const tail = others > 0 ? ` (and ${others} other ${others === 1 ? 'vessel' : 'vessels'})` : ''
+      return (
+        `navigation.position for the own vessel is arriving from ${this.sourcesFor(selfContext).length} sources ` +
+        `(${sources})${tail}. Set source priority for navigation.position, or the track will zigzag between them.`
+      )
+    }
+    return `navigation.position is arriving from multiple sources for ${others} ${others === 1 ? 'vessel' : 'vessels'}.`
+  }
+
+  /** Forget everything seen; used when the plugin restarts. */
+  clear(): void {
+    this.seen.clear()
+  }
+}


### PR DESCRIPTION
The plugin now says so on the dashboard when `navigation.position` is arriving from more than one source.

## Why

A typical boat has several position sources — an internal GPS, an AIS transponder, a plotter echoing its own fix. Signal K resolves which one wins through **source priority**, but `streambundle.getBus('navigation.position')` carries every source's values, not just the winner.

Recording all of them interleaves fixes from receivers metres apart, so the track zigzags between them instead of following the boat. The symptom looks like a noisy GPS; the cause is a missing priority rule, and nothing currently connects the two.

This came up in the track API discussion in SignalK/signalk-server#2504 — any track API reading positions from a stream or a history provider hits the same thing.

## What

A status message on the plugin's dashboard entry:

> navigation.position for the own vessel is arriving from 2 sources (gps.0, n2k.1). Set source priority for navigation.position, or the track will zigzag between them.

The own vessel's sources are named, because that is the track the user looks at and the priority they can fix. Other vessels are counted rather than named — several AIS receivers is normal and not a misconfiguration.

## Notes on the approach

- **Detected empirically**, from what actually arrives, rather than by reading the server's priority config: a rule that exists but does not match still produces multiple sources here.
- **Reported on a 30s timer**, not per delta. At 10Hz across several vessels that would rewrite the status thousands of times a minute, and a single stray fix from a second source is not yet evidence of a problem.
- **Cleared on stop**, since a restart is often how a priority change gets applied — carrying the old observations over would keep warning about a setup that has just been fixed.
- `setPluginStatus` is called optionally, so this is a no-op on a server that does not provide it.

Nothing about recording changes: this reports, it does not filter.

## Tested

- 160 tests pass (148 before, 12 added), `typecheck`, `lint`, `format:check` and `build` all clean.
- Unit coverage of the watcher: single source stays quiet, own-vessel sources named, other vessels counted and pluralised, source-less deltas ignored, first-seen ordering, no self context, and clearing.
- Integration coverage through the plugin with fake timers: the warning reaches the dashboard, a single source stays quiet, and a stopped plugin stops reporting.