### PR TITLE
feat(api): serve per-point times on the all-vessels listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ _If `maxRadius` is specified only vessels with last track position within this d
 _Each entry carries `isSelf`, so the own vessel can be told from an AIS target without
 string-matching the context against the server's self identity._
 
+_`?times` works here too, adding a `times` array to every vessel's entry. Note that asking for
+times also segments each track on the gap threshold, so `coordinates` and `times` line up;
+without `times` each vessel keeps its single unsegmented line._
+
 ---
 
 **Retrieve tracks for all vessels within a given radius (in meters) from your vessel position:**

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,15 @@ import type { TrackStore } from './store.js'
 import { SourceWatch } from './sourceWatch.js'
 import { parseTrackQuery, segment, thin, TimeWindowError } from './timeWindow.js'
 import type { TrackQuery } from './timeWindow.js'
-import type { Context, Debug, LatLngTuple, LngLatTuple, Position, TrackCollection } from './types.js'
+import type {
+  Context,
+  Debug,
+  LatLngTuple,
+  LngLatTuple,
+  Position,
+  TimedTrackCollection,
+  TrackCollection,
+} from './types.js'
 import { resolveContext, toIsoTimes, validateParameters } from './utils.js'
 
 export interface ContextPosition {
@@ -42,6 +50,8 @@ interface AllTracksResult {
   [context: string]: {
     type: 'MultiLineString'
     coordinates: LngLatTuple[][]
+    /** Present only when `?times` was asked for; aligned with `coordinates`. */
+    times?: string[][]
     /**
      * Whether this is the own vessel's track.
      *
@@ -173,15 +183,15 @@ const DEFAULT_MAX_RADIUS = 50 * 1000 //50 kilometers
 // suits the fleet being watched.
 const DEFAULT_SEGMENT_GAP_MINUTES = 0
 
-// Bootstrap retry configuration:
-// First attempt after 5s (sufficient for warm restarts where InfluxDB is already running).
-// Subsequent attempts every 15s, up to 18 total (~260s window), covering cold boot scenarios
-// where InfluxDB may take 2+ minutes to accept connections after systemd reports it active.
 // Long enough that a boat with one GPS never pays for the check in practice,
 // short enough that the warning appears while the user is still looking at the
 // plugin page after enabling it.
 const SOURCE_STATUS_INTERVAL_MS = 30000
 
+// Bootstrap retry configuration:
+// First attempt after 5s (sufficient for warm restarts where InfluxDB is already running).
+// Subsequent attempts every 15s, up to 18 total (~260s window), covering cold boot scenarios
+// where InfluxDB may take 2+ minutes to accept connections after systemd reports it active.
 const BOOTSTRAP_INITIAL_DELAY = 5000
 const BOOTSTRAP_RETRY_DELAY = 15000
 const BOOTSTRAP_MAX_ATTEMPTS = 18
@@ -566,17 +576,40 @@ export default function ThePlugin(app: App): Plugin {
           res.json({ message: err instanceof TimeWindowError ? err.message : 'Invalid query parameters' })
           return
         }
-        tracks
-          .getFilteredTracks(validateParameters(req.query, defaultMaxRadius), getVesselPosition(), app.debug, query)
-          .then((tc: TrackCollection) => {
-            const trks = Object.entries(tc).reduce<AllTracksResult>((acc, [context, track]) => {
-              acc[context] = {
-                type: 'MultiLineString',
-                coordinates: [track.map(toLngLat)],
-                isSelf: context === app.selfContext,
-              }
-              return acc
-            }, {})
+        const params = validateParameters(req.query, defaultMaxRadius)
+        const selfPosition = getVesselPosition()
+
+        // Two paths on purpose. Without `times` the response keeps its
+        // long-standing shape exactly — one un-segmented line per vessel — so
+        // existing clients are unaffected. With `times` the track is segmented
+        // like the single-vessel route, because a times array can only line up
+        // with coordinates if both are split the same way.
+        const result = query.times
+          ? tracks.getFilteredTimedTracks(params, selfPosition, app.debug, query).then((tc: TimedTrackCollection) =>
+              Object.entries(tc).reduce<AllTracksResult>((acc, [context, points]) => {
+                const segments = segment(points, segmentGap)
+                acc[context] = {
+                  type: 'MultiLineString',
+                  coordinates: segments.map((s) => s.map(({ position }) => toLngLat(position))),
+                  times: segments.map(toIsoTimes),
+                  isSelf: context === app.selfContext,
+                }
+                return acc
+              }, {}),
+            )
+          : tracks.getFilteredTracks(params, selfPosition, app.debug, query).then((tc: TrackCollection) =>
+              Object.entries(tc).reduce<AllTracksResult>((acc, [context, track]) => {
+                acc[context] = {
+                  type: 'MultiLineString',
+                  coordinates: [track.map(toLngLat)],
+                  isSelf: context === app.selfContext,
+                }
+                return acc
+              }, {}),
+            )
+
+        result
+          .then((trks) => {
             res.json(trks)
           })
           .catch(() => {

--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -245,3 +245,78 @@ describe('isSelf', () => {
     expect(res.body[OTHER_CONTEXT].isSelf).toBe(false)
   })
 })
+
+// Times on the all-vessels listing. The filtering is shared with the untimed
+// form, so these also pin that the two cannot disagree about which tracks match.
+describe('GET /tracks?times', () => {
+  const T0 = Date.UTC(2026, 7, 14, 9, 0, 0)
+  const MINUTE = 60_000
+
+  const seeded = () => {
+    harness = createHarness({ selfPosition: [60, 24] })
+    harness.seedTrack(
+      SELF_CONTEXT,
+      [
+        [60.1, 24.9],
+        [60.2, 25.0],
+      ],
+      [T0, T0 + MINUTE],
+    )
+    harness.seedTrack(OTHER_CONTEXT, [[60.3, 24.7]], [T0 + 2 * MINUTE])
+    return harness
+  }
+
+  it('omits times unless asked', async () => {
+    const res = await request(seeded().app).get(`${API}/tracks`).expect(200)
+
+    expect(res.body[SELF_CONTEXT].times).toBeUndefined()
+    expect(res.body[SELF_CONTEXT].coordinates).toEqual([
+      [
+        [24.9, 60.1],
+        [25.0, 60.2],
+      ],
+    ])
+  })
+
+  it('serves times aligned with coordinates for every vessel', async () => {
+    const res = await request(seeded().app).get(`${API}/tracks?times`).expect(200)
+
+    expect(res.body[SELF_CONTEXT].times).toEqual([['2026-08-14T09:00:00.000Z', '2026-08-14T09:01:00.000Z']])
+    expect(res.body[OTHER_CONTEXT].times).toEqual([['2026-08-14T09:02:00.000Z']])
+    for (const context of [SELF_CONTEXT, OTHER_CONTEXT]) {
+      const { coordinates, times } = res.body[context]
+      expect(times).toHaveLength(coordinates.length)
+      expect(times[0]).toHaveLength(coordinates[0].length)
+    }
+  })
+
+  it('keeps isSelf alongside the times', async () => {
+    const res = await request(seeded().app).get(`${API}/tracks?times`).expect(200)
+
+    expect(res.body[SELF_CONTEXT].isSelf).toBe(true)
+    expect(res.body[OTHER_CONTEXT].isSelf).toBe(false)
+  })
+
+  it('selects the same vessels with and without times', async () => {
+    // The timed and untimed forms share one filter; a bbox that excludes a
+    // vessel must exclude it either way.
+    const h = seeded()
+    const bbox = 'bbox=60.05,24.5,60.25,25.5'
+
+    const plain = await request(h.app).get(`${API}/tracks?${bbox}`).expect(200)
+    const timed = await request(h.app).get(`${API}/tracks?${bbox}&times`).expect(200)
+
+    expect(Object.keys(timed.body).sort()).toEqual(Object.keys(plain.body).sort())
+    expect(Object.keys(plain.body)).toEqual([SELF_CONTEXT])
+  })
+
+  it('applies the time window to the listing', async () => {
+    const h = seeded()
+
+    const res = await request(h.app)
+      .get(`${API}/tracks?times&from=2026-08-14T09:00:30Z&to=2026-08-14T09:01:30Z`)
+      .expect(200)
+
+    expect(res.body[SELF_CONTEXT].times).toEqual([['2026-08-14T09:01:00.000Z']])
+  })
+})

--- a/src/sqliteStore.ts
+++ b/src/sqliteStore.ts
@@ -11,6 +11,7 @@ import type {
   GeoBounds,
   LatLngTuple,
   TimedPosition,
+  TimedTrackCollection,
   TimeWindow,
   TrackCollection,
   TrackParams,
@@ -255,23 +256,48 @@ export class SqliteTrackStore implements TrackStore {
    * set. It is kept because a prefilter that returns half the table is not
    * worth running, not because correctness depends on it.
    */
-  getFilteredTracks(
+  async getFilteredTracks(
     params: TrackParams,
     selfPosition?: LatLngTuple,
     debug?: Debug,
     query?: TrackQuery,
   ): Promise<TrackCollection> {
+    const timed = await this.getFilteredTimedTracks(params, selfPosition, debug, query)
+    return Object.fromEntries(
+      Object.entries(timed).map(([context, points]) => [context, points.map(({ position }) => position)]),
+    )
+  }
+
+  /**
+   * The same filtering as `getFilteredTracks`, keeping each point's timestamp.
+   *
+   * The untimed form is derived from this one so the two cannot disagree about
+   * which tracks match — both the cell prefilter and the authoritative
+   * last-position test run once, here.
+   */
+  async getFilteredTimedTracks(
+    params: TrackParams,
+    selfPosition?: LatLngTuple,
+    debug?: Debug,
+    query?: TrackQuery,
+  ): Promise<TimedTrackCollection> {
     const candidates = params.bbox ? this.contextsInBounds(params.bbox) : undefined
     const matcher = createMatcher(params, selfPosition, debug)
 
-    return this.getAllTracks(query).then((tracks) =>
-      tracks.reduce<TrackCollection>((acc, { context, track }) => {
-        if ((!candidates || candidates.has(context)) && matcher(track)) {
-          acc[context] = track
-        }
-        return acc
-      }, {}),
+    const tracks = await Promise.all(
+      this.contexts().map((context) =>
+        this.getTimed(context, query?.window).then((points) => ({
+          context,
+          points: thin(points, query?.resolution),
+        })),
+      ),
     )
+    return tracks.reduce<TimedTrackCollection>((acc, { context, points }) => {
+      if ((!candidates || candidates.has(context)) && matcher(points.map(({ position }) => position))) {
+        acc[context] = points
+      }
+      return acc
+    }, {})
   }
 
   /** Contexts with at least one position inside `bounds`, via the cell index. */

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -107,4 +107,54 @@ describe.each(implementations)('TrackStore contract: %s', (_name, newStore) => {
     const remaining = await store.getAllTracks()
     expect(remaining.map(({ context }) => context)).toEqual([ctx])
   })
+
+  it('returns timed tracks carrying each point timestamp', async () => {
+    const store = newStore()
+    // initialTrack, not newPosition: the in-memory accumulator throttles on the
+    // wall clock, so a synchronous burst of positions yields a single point.
+    store.initialTrack(
+      ctx,
+      [
+        [60, 25],
+        [60.1, 25.1],
+      ],
+      [1000, 2000],
+    )
+    const timed = await store.getFilteredTimedTracks({ bbox: null, radius: null })
+    expect(timed[ctx]).toEqual([
+      { position: [60, 25], timestamp: 1000 },
+      { position: [60.1, 25.1], timestamp: 2000 },
+    ])
+  })
+
+  it('selects the same contexts timed and untimed', async () => {
+    // Both forms share one filter; if they diverge, a client asking for times
+    // silently gets a different set of vessels.
+    const store = newStore()
+    store.newPosition(ctx, [60, 25], 1000)
+    store.newPosition('vessels.far' as Context, [10, 10], 1000)
+    const params = { bbox: { sw: [59, 24] as [number, number], ne: [61, 26] as [number, number] }, radius: null }
+
+    const plain = await store.getFilteredTracks(params)
+    const timed = await store.getFilteredTimedTracks(params)
+
+    expect(Object.keys(timed).sort()).toEqual(Object.keys(plain).sort())
+    expect(Object.keys(plain)).toEqual([ctx])
+  })
+
+  it('narrows a timed track to the requested window', async () => {
+    const store = newStore()
+    store.initialTrack(
+      ctx,
+      [
+        [60, 25],
+        [60.1, 25.1],
+      ],
+      [1000, 5000],
+    )
+    const timed = await store.getFilteredTimedTracks({ bbox: null, radius: null }, undefined, undefined, {
+      window: { from: 4000, to: 6000, inclusiveEnd: true },
+    })
+    expect(timed[ctx]).toEqual([{ position: [60.1, 25.1], timestamp: 5000 }])
+  })
 })

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,13 @@
-import type { Context, Debug, LatLngTuple, TimedPosition, TimeWindow, TrackCollection, TrackParams } from './types.js'
+import type {
+  Context,
+  Debug,
+  LatLngTuple,
+  TimedPosition,
+  TimedTrackCollection,
+  TimeWindow,
+  TrackCollection,
+  TrackParams,
+} from './types.js'
 import type { TrackQuery } from './timeWindow.js'
 
 /**
@@ -43,6 +52,14 @@ export interface TrackStore {
 
   /** Every known context and its track, thinned to `query.resolution`. */
   getAllTracks(query?: TrackQuery): Promise<{ context: string; track: LatLngTuple[] }[]>
+
+  /** As `getFilteredTracks`, but keeping the timestamp of each point. */
+  getFilteredTimedTracks(
+    params: TrackParams,
+    selfPosition?: LatLngTuple,
+    debug?: Debug,
+    query?: TrackQuery,
+  ): Promise<TimedTrackCollection>
 
   /**
    * Tracks whose *last* position matches a spatial predicate.

--- a/src/tracks.ts
+++ b/src/tracks.ts
@@ -4,7 +4,16 @@ import { map, scan, startWith, throttleTime } from 'rxjs/operators'
 import { thin } from './timeWindow.js'
 import type { TrackQuery } from './timeWindow.js'
 import type { TrackStore } from './store.js'
-import type { Context, Debug, LatLngTuple, TimedPosition, TimeWindow, TrackCollection, TrackParams } from './types.js'
+import type {
+  Context,
+  Debug,
+  LatLngTuple,
+  TimedPosition,
+  TimedTrackCollection,
+  TimeWindow,
+  TrackCollection,
+  TrackParams,
+} from './types.js'
 import { createMatcher } from './utils.js'
 
 interface TracksMap {
@@ -104,18 +113,45 @@ export class Tracks implements TrackStore {
     debug?: Debug,
     query?: TrackQuery,
   ): Promise<TrackCollection> {
+    const timed = await this.getFilteredTimedTracks(params, selfPosition, debug, query)
+    return Object.fromEntries(
+      Object.entries(timed).map(([context, points]) => [context, points.map(({ position }) => position)]),
+    )
+  }
+
+  /**
+   * The same filtering as `getFilteredTracks`, keeping each point's timestamp.
+   *
+   * The untimed form is derived from this one so the two cannot disagree about
+   * which tracks match — the filter runs once, here.
+   */
+  async getFilteredTimedTracks(
+    params: TrackParams,
+    selfPosition?: LatLngTuple,
+    debug?: Debug,
+    query?: TrackQuery,
+  ): Promise<TimedTrackCollection> {
     this.debug(params)
     this.debug('Self position', selfPosition)
     const matcher = createMatcher(params, selfPosition, debug)
 
-    return this.getAllTracks(query).then((contextTracks) => {
-      return contextTracks.reduce<TrackCollection>((acc, { context, track }) => {
-        if (matcher(track)) {
-          acc[context] = track
-        }
-        return acc
-      }, {})
-    })
+    const contexts = Object.keys(this.tracks)
+    const tracks = await Promise.all(
+      contexts.map((context) =>
+        this.getTimed(context, query?.window).then((points) => ({
+          context,
+          points: thin(points, query?.resolution),
+        })),
+      ),
+    )
+    return tracks.reduce<TimedTrackCollection>((acc, { context, points }) => {
+      // The matcher tests the last *position*, so it sees the same geometry it
+      // always did; only what is carried alongside changed.
+      if (matcher(points.map(({ position }) => position))) {
+        acc[context] = points
+      }
+      return acc
+    }, {})
   }
 
   prune(maxAge: number): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,11 @@ export interface TrackCollection {
   [key: string]: LatLngTuple[]
 }
 
+/** As `TrackCollection`, but each point keeps the time it was recorded. */
+export interface TimedTrackCollection {
+  [key: string]: TimedPosition[]
+}
+
 export interface GeoBounds {
   ne: LatLngTuple
   sw: LatLngTuple


### PR DESCRIPTION
`?times` now works on `/tracks`, not just the single-vessel routes.

## Why

#50 added per-point recording times, but only where the handler already had them. `/tracks` goes through `getFilteredTracks`, which returns a `TrackCollection` — positions only — so the timestamps were dropped inside the store rather than at the response boundary.

That left the parameter working on one route and silently ignored on another, and it is the listing route that matters for the AIS case in SignalK/signalk-server#2504: drawing several vessels as time-spaced dots needs times for all of them.

## What

`getFilteredTimedTracks` joins the `TrackStore` interface, implemented by both the in-memory and sqlite stores.

The untimed form is now **derived from** the timed one, so the two cannot disagree about which tracks match — the spatial filter, and for sqlite the S2 cell prefilter, run once in one place. A contract test pins that both forms select the same contexts.

```
GET /signalk/v1/api/tracks?times
```

```json
{
  "vessels.urn:mrn:imo:mmsi:123456789": {
    "type": "MultiLineString",
    "coordinates": [[[24.9, 60.1], [25.0, 60.2]]],
    "times": [["2026-08-14T09:00:00.000Z", "2026-08-14T09:01:00.000Z"]],
    "isSelf": true
  }
}
```

## One behaviour worth noting

Asking for `times` also **segments** each track on the gap threshold, because a times array can only line up with coordinates if both are split the same way. Without the parameter each vessel keeps its single unsegmented line, exactly as before.

So the default response is unchanged, and the timed response matches the single-vessel route's shape.

## Tested

- 171 tests pass (160 before, 11 added), `typecheck`, `lint`, `format:check` and `build` all clean.
- Contract tests run against **both** store implementations: timestamps carried through, identical context selection timed vs untimed, and window narrowing.
- Route tests: absent without the parameter, aligned arrays for every vessel, `isSelf` preserved, identical vessel selection under a bbox, and the time window applied to the listing.