### PR TITLE
test: add an end-to-end suite against a real server and QuestDB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,23 @@ The package is **ESM only** (`"type": "module"`) and ships only `dist/`.
 npm ci
 npm run build      # vite library build -> dist/index.js + rolled-up index.d.ts
 npm test           # vitest
+npm run test:e2e   # real signalk-server + real QuestDB; never in CI
 npm run typecheck  # tsc --noEmit (the build itself does not typecheck)
 npm run lint       # eslint flat config
 npm run format     # prettier --write
 ```
+
+**`npm run test:e2e` needs a built `signalk-server` checkout.** It packs the plugin with
+`npm pack`, installs the tarball into a throwaway config dir, boots a real server against it,
+and feeds positions as deltas over the WebSocket API. That covers what the unit suite mocks:
+that the server can resolve and load the package at all (the `main`-vs-`exports` trap above),
+that `signalKApiRoutes` mounts where it should, and that deltas reach the plugin through the
+real streambundle.
+
+Point it at a checkout with `SIGNALK_SERVER_DIR`, default `~/dev/xxx_signalk-server`; build
+that checkout first with `npm run build:all`. The QuestDB tier is read-only and skips itself
+when nothing answers at `QUESTDB_URL` (default `http://localhost:9000`), so the server tier
+still runs without it.
 
 `tsconfig.json` is strict and then some — `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `noImplicitReturns`, `noUnusedLocals`. Keep them on; they caught real bugs when they went in.
 

--- a/README.md
+++ b/README.md
@@ -147,10 +147,18 @@ with `lon1` greater than `lon2`, for example `bbox=-10,175,10,-175`._
 npm ci
 npm run build      # vite library build -> dist/
 npm test           # vitest
+npm run test:e2e   # against a real signalk-server; see below
 npm run typecheck  # tsc --noEmit
 npm run lint       # eslint
 npm run format     # prettier --write
 ```
+
+`npm run test:e2e` packs the plugin, installs it into a throwaway config directory, boots a real
+Signal K server against it and feeds positions as deltas — so it covers plugin loading, route
+mounting and the delta path, none of which the unit suite can. It needs a built server checkout;
+set `SIGNALK_SERVER_DIR` if yours is not at `~/dev/xxx_signalk-server`. A second tier checks a
+running QuestDB as a backfill source and skips itself if none is reachable at `QUESTDB_URL`.
+Neither tier runs in CI.
 
 The package is ESM only and targets Node >= 22.5.0, the release that added `node:sqlite`. ESM alone
 would only need 20.19, the first release in which the Signal K server's `require()`-based plugin

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -15,7 +15,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['**/*.test.ts', 'vite.config.ts', 'eslint.config.ts'],
+    files: ['**/*.test.ts', '**/*.test-utils.ts', 'vite.config.ts', 'vitest.e2e.config.ts', 'eslint.config.ts'],
     ...tseslint.configs.disableTypeChecked,
   },
   prettier,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "prepublishOnly": "npm run typecheck && npm run lint && npm run build"
   },
   "license": "Apache-2.0",

--- a/src/backfill.e2e.test.ts
+++ b/src/backfill.e2e.test.ts
@@ -1,0 +1,88 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { questdb, questdbAvailable, QUESTDB_URL } from './e2e.test-utils.js'
+
+/**
+ * QuestDB as a backfill source.
+ *
+ * The unit suite stubs `getHistoryApi`, which proves the plugin's own parsing
+ * but says nothing about whether a real provider's storage fits it. These
+ * queries run against a live QuestDB — the store signalk-questdb writes into —
+ * so a change on either side shows up here.
+ *
+ * Read-only against the real rows. QuestDB has no row-level DELETE (it drops
+ * whole time partitions instead), so a fixture context could not be cleaned up
+ * afterwards; asserting against what is genuinely recorded avoids leaving
+ * synthetic vessels behind in the table.
+ *
+ * Skips cleanly when QuestDB is not reachable, so `npm run test:e2e` still runs
+ * the server tier without it.
+ */
+
+let available = false
+
+beforeAll(async () => {
+  available = await questdbAvailable()
+  if (!available) {
+    console.warn(`QuestDB not reachable at ${QUESTDB_URL}; backfill tests skipped`)
+  }
+}, 60_000)
+
+describe('QuestDB as a history source', () => {
+  it('stores navigation.position in its own table', async () => {
+    if (!available) return
+    // The schema the History API bootstrap ultimately reads through. A rename
+    // here is what would silently empty a backfilled track.
+    const res = await questdb(`SELECT "column", type FROM table_columns('signalk_position')`)
+    const columns = Object.fromEntries(res.dataset.map((row) => [row[0], row[1]]))
+
+    expect(columns).toMatchObject({
+      ts: 'TIMESTAMP',
+      context: 'SYMBOL',
+      lat: 'DOUBLE',
+      lon: 'DOUBLE',
+    })
+  })
+
+  it('has no path column: the whole table is navigation.position', async () => {
+    if (!available) return
+    // Worth pinning because it is the reason positions can be time-partitioned
+    // separately from every other path, which is what makes a track query fast.
+    const res = await questdb(`SELECT "column" FROM table_columns('signalk_position')`)
+    expect(res.dataset.flat()).not.toContain('path')
+  })
+
+  it('records more than one vessel', async () => {
+    if (!available) return
+    // Not asserting a count, which grows: the point is that the backfill source
+    // is genuinely multi-vessel, which is what makes the self/AIS split real.
+    const res = await questdb('SELECT count(DISTINCT context) FROM signalk_position')
+    expect(res.dataset[0]?.[0] as number).toBeGreaterThan(1)
+  })
+
+  it('answers a bounded time query, which is what a track backfill issues', async () => {
+    if (!available) return
+    const res = await questdb(`SELECT count() FROM signalk_position WHERE ts > dateadd('d', -1, now()) AND ts <= now()`)
+    expect(res.dataset[0]?.[0] as number).toBeGreaterThanOrEqual(0)
+  })
+
+  it('returns positions oldest-first when ordered by ts', async () => {
+    if (!available) return
+    // The bootstrap appends rows in the order it receives them, so a provider
+    // returning them unordered would produce a track that doubles back.
+    const res = await questdb(`SELECT ts FROM signalk_position WHERE ts > dateadd('d', -7, now()) ORDER BY ts LIMIT 50`)
+    const timestamps = res.dataset.map((row) => Date.parse(String(row[0])))
+    if (timestamps.length < 2) return
+    const sorted = [...timestamps].sort((a, b) => a - b)
+    expect(timestamps).toEqual(sorted)
+  })
+
+  it('has no source column, so interleaved sources are indistinguishable', async () => {
+    if (!available) return
+    // Pins the gap behind the multi-source warning: once recorded, fixes from
+    // several receivers cannot be told apart or filtered after the fact.
+    const res = await questdb(`SELECT "column" FROM table_columns('signalk_position')`)
+    const columns = res.dataset.flat()
+    expect(columns).not.toContain('source')
+    expect(columns).not.toContain('$source')
+  })
+})

--- a/src/e2e.test-utils.ts
+++ b/src/e2e.test-utils.ts
@@ -1,0 +1,202 @@
+import { spawn } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Boots a real Signal K server with this plugin installed.
+ *
+ * The unit suite drives the plugin behind a bare express app, which proves the
+ * handlers but mocks everything around them. This proves the parts that mock
+ * cannot: that the server resolves and loads the built package at all, that
+ * `signalKApiRoutes` actually mounts under /signalk/v1/api, and that positions
+ * arriving as deltas reach the plugin through the real streambundle.
+ *
+ * Deliberately not in CI. It needs a built server checkout and, for the
+ * backfill tests, a running QuestDB.
+ */
+
+/** Where the signalk-server checkout lives. Override with SIGNALK_SERVER_DIR. */
+const SERVER_DIR = process.env.SIGNALK_SERVER_DIR ?? join(process.env.HOME ?? '', 'dev/xxx_signalk-server')
+
+/** QuestDB HTTP endpoint for the backfill tier. */
+export const QUESTDB_URL = process.env.QUESTDB_URL ?? 'http://localhost:9000'
+
+export interface E2EServer {
+  url: string
+  configDir: string
+  /** Send a position delta as a provider would, over the WebSocket API. */
+  feed: (context: string, position: [number, number], timestamp?: number, source?: string) => Promise<void>
+  /** GET a path under /signalk/v1/api and parse the JSON. */
+  api: (path: string) => Promise<unknown>
+  stop: () => void
+}
+
+/** A port unlikely to collide with a dev server or the boat's own services. */
+const basePort = 4700 + Math.floor(process.pid % 50)
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Install the plugin into a throwaway config dir from a packed tarball.
+ *
+ * A tarball rather than a link: `npm pack` applies the `files` allowlist, so
+ * this fails the same way a user's install would if the build output or
+ * package.json `main` were wrong — which is one of the things worth proving.
+ */
+function installPlugin(configDir: string, repoRoot: string): void {
+  execFileSync('npm', ['run', 'build'], { cwd: repoRoot, stdio: 'pipe' })
+  const packed = execFileSync('npm', ['pack', '--pack-destination', configDir, '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+  // npm pack --json has two shapes across versions: an array of results, or an
+  // object keyed by filename.
+  const parsed: unknown = JSON.parse(packed)
+  const filename = Array.isArray(parsed)
+    ? (parsed[0] as { filename: string }).filename
+    : Object.values(parsed as Record<string, { filename: string }>)[0]?.filename
+  if (!filename) {
+    throw new Error(`could not read a filename out of npm pack --json: ${packed}`)
+  }
+  writeFileSync(join(configDir, 'package.json'), JSON.stringify({ name: 'sk-e2e-config', private: true }, null, 2))
+  execFileSync('npm', ['install', join(configDir, filename)], { cwd: configDir, stdio: 'pipe' })
+}
+
+export interface E2EOptions {
+  /** Plugin configuration written to plugin-config-data/tracks.json. */
+  config?: Record<string, unknown>
+  /** Seconds to wait for the server to answer before giving up. */
+  timeoutSeconds?: number
+}
+
+export async function startServer(options: E2EOptions = {}): Promise<E2EServer> {
+  const repoRoot = process.cwd()
+  const configDir = mkdtempSync(join(tmpdir(), 'sk-tracks-e2e-'))
+  installPlugin(configDir, repoRoot)
+
+  mkdirSync(join(configDir, 'plugin-config-data'), { recursive: true })
+  writeFileSync(
+    join(configDir, 'plugin-config-data', 'tracks.json'),
+    JSON.stringify(
+      {
+        enabled: true,
+        configuration: {
+          resolution: 0,
+          pointsToKeep: 1000,
+          maxAge: 3600,
+          source: 'memory',
+          ...options.config,
+        },
+      },
+      null,
+      2,
+    ),
+  )
+
+  const port = basePort
+  const child: ChildProcess = spawn('node', ['bin/signalk-server', '-c', configDir], {
+    cwd: SERVER_DIR,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      // The server's own NMEA and TCP listeners collide with a dev server or
+      // the boat's, and a failed bind there would otherwise abort the boot.
+      NMEA0183PORT: String(port + 100),
+      TCPSTREAMPORT: String(port + 200),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  const log: string[] = []
+  child.stdout?.on('data', (d: Buffer) => log.push(d.toString()))
+  child.stderr?.on('data', (d: Buffer) => log.push(d.toString()))
+
+  const url = `http://localhost:${port}`
+  const stop = () => {
+    child.kill('SIGTERM')
+    rmSync(configDir, { recursive: true, force: true })
+  }
+
+  const deadline = Date.now() + (options.timeoutSeconds ?? 60) * 1000
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${url}/signalk`, { signal: AbortSignal.timeout(2000) })
+      if (res.ok) {
+        return {
+          url,
+          configDir,
+          feed: (context, position, timestamp, source) => feedDelta(url, context, position, timestamp, source),
+          api: async (path: string) => {
+            const r = await fetch(`${url}/signalk/v1/api${path}`)
+            return r.json()
+          },
+          stop,
+        }
+      }
+    } catch {
+      // not up yet
+    }
+    await wait(500)
+  }
+
+  stop()
+  throw new Error(`signalk-server did not start within the timeout. Output:\n${log.join('')}`)
+}
+
+/**
+ * Push a position delta over the WebSocket API.
+ *
+ * Via the real delta path rather than by calling the plugin: that is what makes
+ * this an end-to-end test rather than a slower unit test.
+ */
+async function feedDelta(
+  url: string,
+  context: string,
+  position: [number, number],
+  timestamp?: number,
+  source = 'e2e.gps',
+): Promise<void> {
+  const ws = new WebSocket(`${url.replace('http', 'ws')}/signalk/v1/stream?subscribe=none`)
+  await new Promise<void>((resolve, reject) => {
+    ws.onopen = () => resolve()
+    ws.onerror = () => reject(new Error('websocket failed to open'))
+  })
+  ws.send(
+    JSON.stringify({
+      context,
+      updates: [
+        {
+          $source: source,
+          timestamp: new Date(timestamp ?? Date.now()).toISOString(),
+          values: [{ path: 'navigation.position', value: { latitude: position[0], longitude: position[1] } }],
+        },
+      ],
+    }),
+  )
+  // The send is fire-and-forget; give the server a moment to apply it before
+  // the socket closes.
+  await wait(250)
+  ws.close()
+}
+
+/** Run a SQL statement against QuestDB's HTTP endpoint. */
+export async function questdb(sql: string): Promise<{ dataset: unknown[][] }> {
+  const res = await fetch(`${QUESTDB_URL}/exec?query=${encodeURIComponent(sql)}`)
+  if (!res.ok) {
+    throw new Error(`QuestDB rejected the query (${res.status}): ${await res.text()}`)
+  }
+  return (await res.json()) as { dataset: unknown[][] }
+}
+
+/** Whether QuestDB is reachable, so the backfill tier can skip cleanly. */
+export async function questdbAvailable(): Promise<boolean> {
+  try {
+    await questdb('SELECT 1')
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/plugin.e2e.test.ts
+++ b/src/plugin.e2e.test.ts
@@ -1,0 +1,108 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { startServer } from './e2e.test-utils.js'
+import type { E2EServer } from './e2e.test-utils.js'
+
+/**
+ * The plugin inside a real Signal K server.
+ *
+ * Run with `npm run test:e2e`; excluded from the default suite because it needs
+ * a built server checkout at SIGNALK_SERVER_DIR.
+ */
+
+const CTX = 'vessels.urn:mrn:imo:mmsi:244170001'
+const MINUTE = 60_000
+
+interface TrackResponse {
+  type: string
+  coordinates: [number, number][][]
+  times?: string[][]
+  isSelf?: boolean
+  context?: string
+}
+
+let server: E2EServer
+
+beforeAll(async () => {
+  server = await startServer({ config: { segmentGapMinutes: 5 } })
+}, 180_000)
+
+afterAll(() => {
+  server?.stop()
+})
+
+describe('the server loads and mounts the plugin', () => {
+  it('serves the track API under /signalk/v1/api', async () => {
+    // Proves what the unit suite cannot: the server resolved the packaged
+    // plugin by directory, imported it, and mounted signalKApiRoutes.
+    await expect(server.api('/tracks')).resolves.toEqual({})
+  })
+})
+
+describe('positions arriving as deltas', () => {
+  it('reaches the plugin through the real streambundle', async () => {
+    const t0 = Date.now() - 10 * MINUTE
+    await server.feed(CTX, [60.1, 24.9], t0)
+    await server.feed(CTX, [60.11, 24.91], t0 + MINUTE)
+
+    const tracks = (await server.api('/tracks')) as Record<string, TrackResponse>
+    expect(Object.keys(tracks)).toContain(CTX)
+    expect(tracks[CTX]?.type).toBe('MultiLineString')
+  })
+
+  it('files points at the delta timestamp, not arrival time', async () => {
+    // Both positions are sent now but dated ten minutes ago; a time window
+    // around the delta timestamps must find them.
+    const t0 = Date.now() - 10 * MINUTE
+    const from = new Date(t0 - MINUTE).toISOString()
+    const to = new Date(t0 + 5 * MINUTE).toISOString()
+
+    const track = (await server.api(`/vessels/${CTX.replace('vessels.', '')}/track?from=${from}&to=${to}&times`)) as
+      TrackResponse | undefined
+
+    expect(track?.times?.[0]?.length).toBeGreaterThan(0)
+  })
+
+  it('serves per-point times through the real server', async () => {
+    const track = (await server.api(`/vessels/${CTX.replace('vessels.', '')}/track?times`)) as TrackResponse
+
+    expect(track.times).toBeDefined()
+    expect(track.times?.[0]?.[0]).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/)
+    expect(track.times?.[0]?.length).toBe(track.coordinates[0]?.length)
+  })
+
+  it('reports the context and isSelf', async () => {
+    const track = (await server.api(`/vessels/${CTX.replace('vessels.', '')}/track`)) as TrackResponse
+
+    expect(track.context).toBe(CTX)
+    // The fed vessel is not the server's own, which has no position here.
+    expect(track.isSelf).toBe(false)
+  })
+
+  it('distinguishes vessels in the all-tracks listing', async () => {
+    const other = 'vessels.urn:mrn:imo:mmsi:244170002'
+    await server.feed(other, [59.5, 24.2], Date.now() - MINUTE)
+
+    const tracks = (await server.api('/tracks?times')) as Record<string, TrackResponse>
+
+    expect(Object.keys(tracks).sort()).toEqual([CTX, other].sort())
+    for (const context of Object.keys(tracks)) {
+      expect(tracks[context]?.isSelf).toBe(false)
+      expect(tracks[context]?.times).toBeDefined()
+    }
+  })
+})
+
+describe('query parameters through the real server', () => {
+  it('400s on an invalid time window rather than 500ing', async () => {
+    const res = await fetch(`${server.url}/signalk/v1/api/tracks?from=not-a-date`)
+    expect(res.status).toBe(400)
+  })
+
+  it('excludes everything with a window in the far past', async () => {
+    const track = (await server.api(
+      `/vessels/${CTX.replace('vessels.', '')}/track?from=2000-01-01T00:00:00Z&to=2000-01-02T00:00:00Z`,
+    )) as TrackResponse
+
+    expect(track.coordinates).toEqual([])
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,5 +24,8 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    // e2e runs against a real Signal K server and a real QuestDB, neither of
+    // which exists in CI. `npm run test:e2e` opts in.
+    exclude: ['**/node_modules/**', '**/dist/**', 'src/**/*.e2e.test.ts'],
   },
 })

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+// The e2e tier: a real Signal K server, and for the backfill tests a real
+// QuestDB. Serial and long-timeout because each file boots a server process.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.e2e.test.ts'],
+    testTimeout: 60_000,
+    hookTimeout: 180_000,
+    fileParallelism: false,
+  },
+})


### PR DESCRIPTION
`npm run test:e2e` runs the plugin inside a real Signal K server.

## Why

The unit suite drives the plugin behind a bare express app. That proves the handlers, but mocks everything around them — and three failure modes live in what it mocks:

- the server failing to **resolve and load** the packaged module at all (the `main`-vs-`exports` trap already documented in AGENTS.md),
- `signalKApiRoutes` **not mounting** where it should,
- deltas **not reaching the plugin** through the real streambundle.

Each has broken a Signal K plugin before, and none is visible until someone installs it.

## What it does

1. `npm pack` — so the `files` allowlist and module resolution are exercised exactly as a user's install would be, not via a symlink that hides both.
2. Installs the tarball into a throwaway config directory.
3. Boots a real `signalk-server` against it, with the NMEA and TCP ports moved so a dev server or the boat's own services do not collide.
4. Feeds positions as deltas over the **WebSocket API**, the way a provider does.

Then asserts: routes mount, per-point `times` are served and aligned, `context` and `isSelf` are right, points are filed at the **delta timestamp** rather than arrival time, and a malformed time window returns 400 rather than 500.

## The QuestDB tier

A second file reads a live QuestDB, pinning the schema the History bootstrap ultimately depends on: `signalk_position` exists with `ts`/`context`/`lat`/`lon`, has no `path` column (which is what lets positions be time-partitioned separately), and returns rows oldest-first.

It also pins the gap behind #52 — **no source column**, so once several receivers' fixes are recorded they cannot be told apart after the fact.

Read-only against the real rows. QuestDB drops whole time partitions rather than individual rows, so a seeded fixture context could not be cleaned up afterwards; asserting against what is genuinely recorded avoids leaving synthetic vessels in the table.

## Not in CI

Both tiers are excluded from `npm test` and from the CI matrix, which has neither a built server nor a database. `SIGNALK_SERVER_DIR` points at the checkout (default `~/dev/xxx_signalk-server`); the QuestDB tier skips itself when nothing answers at `QUESTDB_URL`.

## Tested

- `npm run test:e2e`: **14 tests pass** against a real server and a QuestDB holding ~1.2M positions across 317 contexts.
- `npm test` unchanged at **171**, confirming the e2e files are excluded from the default run.
- `typecheck`, `lint`, `format:check` and `build` all clean.