### PR TITLE
docs: correct why several position sources reach the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ vessel, exposing the result as `Observable<LatLngTuple[]>`.
 
 `navigation.position` often arrives from several sources at once — an internal GPS, an AIS
 transponder, a plotter echoing its own fix. Signal K decides which one wins through **source
-priority**, but the stream this plugin listens on carries them all.
+priority**, and the stream this plugin records from is already filtered by it, so normally only
+the winning source is stored.
 
-Recording every source interleaves fixes from receivers metres apart, so the track zigzags
-between them instead of following the boat. If that is happening, the plugin says so in its
-status on the server dashboard, naming the sources it has seen. The fix is to set a source
-priority for `navigation.position` in the server settings.
+When no priority rule matches the path, though, every source comes through. Their fixes are
+metres apart, so the track zigzags between receivers instead of following the boat. If that is
+happening, the plugin says so in its status on the server dashboard, naming the sources it has
+seen. The fix is to set a source priority for `navigation.position` in the server settings.
 
 # Usage:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,11 @@ export interface ContextPosition {
   /** ISO-8601 time the value was recorded, as carried by the Signal K delta. */
   timestamp?: string
   /**
-   * Which source produced the value. The bus carries every source's values,
-   * not just the one source priority selects, so this is how a multi-receiver
-   * setup is detected.
+   * Which source produced the value.
+   *
+   * The bus is priority-filtered, so normally this is the one source the
+   * server selected. Seeing several for one context means no priority rule is
+   * matching the path — which is what `SourceWatch` reports on.
    */
   $source?: string
 }

--- a/src/sourceWatch.test.ts
+++ b/src/sourceWatch.test.ts
@@ -91,6 +91,20 @@ describe('SourceWatch', () => {
     expect(w.warning(undefined)).toContain('1 vessel')
   })
 
+  it('stays quiet when the server has already picked a winner', () => {
+    // The premise the warning rests on: getBus() is fed from `delta`, which the
+    // server emits *after* applying toPreferredDelta. With a priority rule in
+    // place only the winning source arrives, so a correctly configured boat
+    // never sees this warning however many receivers it has.
+    const w = new SourceWatch()
+    for (let i = 0; i < 100; i++) {
+      w.add(SELF, 'gps.0')
+    }
+
+    expect(w.conflicted()).toEqual([])
+    expect(w.warning(SELF)).toBeUndefined()
+  })
+
   it('forgets what it saw when cleared', () => {
     const w = new SourceWatch()
     w.add(SELF, 'gps.0')

--- a/src/sourceWatch.ts
+++ b/src/sourceWatch.ts
@@ -5,19 +5,23 @@ import type { Context } from './types.js'
  *
  * `navigation.position` is a rapid update — a GPS may report at 10Hz — and a
  * typical boat has several receivers: an internal GPS, an AIS transponder, a
- * chart plotter echoing its own fix. Signal K resolves which one *wins* per
- * path through source priority, but the streambundle bus this plugin listens
- * on carries every source's values, not just the winner.
+ * chart plotter echoing its own fix.
  *
- * Recording all of them interleaves fixes from receivers metres apart, so the
+ * Signal K resolves which one wins through source priority, and the bus this
+ * plugin listens on is the filtered one: the server applies `toPreferredDelta`
+ * before emitting `delta`, which is what feeds `getBus()`. So with a priority
+ * rule in place, only the winner arrives and there is nothing to warn about.
+ *
+ * The gap is when no rule *matches* the path. Then the engine passes every
+ * source through, the fixes from receivers metres apart interleave, and the
  * track zigzags between them rather than following the boat. The fix is to
  * configure source priority for `navigation.position`; this watcher exists to
  * say so, because the symptom (a track that looks noisy) does not obviously
  * point at the cause.
  *
- * Detection is empirical rather than reading the server's priority config:
- * what matters is what actually arrives, and a priority rule that exists but
- * does not match still produces multiple sources here.
+ * Detection is therefore empirical rather than reading the priority config:
+ * seeing several sources here *is* the evidence that no rule is matching,
+ * which a config that merely exists would not tell us.
  */
 export class SourceWatch {
   private readonly seen = new Map<Context, Set<string>>()


### PR DESCRIPTION
Corrects the rationale behind the multi-source warning added in #52. **No behaviour change.**

## What was wrong

#52 explained the warning as:

> the streambundle bus this plugin listens on carries every source's values, not just the winner

That is not right. In `signalk-server`, `dispatchDelta` applies `toPreferredDelta` **before** emitting:

```ts
const preferred = toPreferredDelta(handled, now, app.selfContext)
if (version === SKVersion.v1) {
  app.signalk.addDelta(preferred)
} else {
  app.signalk.emit('delta', preferred)
}
```

and the streambundle is wired to that filtered event:

```ts
app.signalk.on('delta', app.streambundle.pushDelta.bind(app.streambundle))
app.signalk.on('unfilteredDelta', app.streambundle.pushUnfilteredDelta.bind(app.streambundle))
```

`getBus()` reads the first. The raw stream is a separate `getUnfilteredBus()`, which this plugin does not use.

So the stream **is** priority-filtered: a boat with five receivers and a working priority rule records only the winner, and never sees the warning.

## What is actually true

Several sources arrive when **no priority rule matches the path**. The engine then passes them all through, their fixes interleave, and the track zigzags between receivers.

That is a narrower claim than the original, and it is the one the warning genuinely detects. It also explains why detection has to be empirical rather than reading the priority config: seeing several sources here *is* the evidence that nothing is matching, which a config that merely exists would not tell you.

## Why this matters beyond wording

The overstated version implies the plugin should filter by source itself. It should not — that would duplicate the server's own mechanism and diverge from it the moment a user configures a rule. Getting the rationale right is what keeps that from looking like a missing feature.

## Changes

- Rewritten doc comments on `SourceWatch` and `ContextPosition.$source`.
- README "Position sources" section corrected.
- A test pinning the premise: a single source repeated many times never warns.

The warning message itself was already accurate and is unchanged.

## Tested

172 tests pass (171 before, 1 added); `typecheck`, `lint` and `format:check` clean.